### PR TITLE
Release/v0.5.2: Fixed libraries vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [released]
+
+## [0.5.2] - 2023-04-13
+
+## Security Issues
+
+- Updated Spring Boot Version from `v3.0.2` to `v3.0.5` fixing the following vulnerable libraries:
+  - Spring Expression *v6.0.4* -> `v6.0.7`
+  - JSON Smart *v2.4.8* -> `v2.4.10`
+
 ## [released]
 
 ## [0.5.1] - 2023-03-31

--- a/DEPENDENCIES_BACKEND
+++ b/DEPENDENCIES_BACKEND
@@ -85,7 +85,7 @@ maven/mavencentral/org.springdoc/springdoc-openapi-starter-common/2.0.2, Apache-
 maven/mavencentral/org.springdoc/springdoc-openapi-starter-webmvc-api/2.0.2, Apache-2.0, approved, #5950
 maven/mavencentral/org.springdoc/springdoc-openapi-starter-webmvc-ui/2.0.2, Apache-2.0, approved, #5923
 maven/mavencentral/org.springframework.boot/spring-boot-autoconfigure/3.0.5, Apache-2.0, approved, #6981
-maven/mavencentral/org.springframework.boot/spring-boot-starter-data-rest/3.0.5, , restricted, clearlydefined
+maven/mavencentral/org.springframework.boot/spring-boot-starter-data-rest/3.0.5, Apache-2.0, approved, #7861
 maven/mavencentral/org.springframework.boot/spring-boot-starter-json/3.0.5, Apache-2.0, approved, #7006
 maven/mavencentral/org.springframework.boot/spring-boot-starter-logging/3.0.5, Apache-2.0, approved, #6982
 maven/mavencentral/org.springframework.boot/spring-boot-starter-oauth2-client/3.0.5, Apache-2.0, approved, #5932
@@ -101,8 +101,8 @@ maven/mavencentral/org.springframework.cloud/spring-cloud-context/3.1.5, Apache-
 maven/mavencentral/org.springframework.cloud/spring-cloud-starter-bootstrap/3.1.5, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.springframework.cloud/spring-cloud-starter/3.1.5, Apache-2.0, approved, #4723
 maven/mavencentral/org.springframework.data/spring-data-commons/3.0.4, Apache-2.0, approved, #5943
-maven/mavencentral/org.springframework.data/spring-data-rest-core/4.0.4, , restricted, clearlydefined
-maven/mavencentral/org.springframework.data/spring-data-rest-webmvc/4.0.4, , restricted, clearlydefined
+maven/mavencentral/org.springframework.data/spring-data-rest-core/4.0.4, Apache-2.0, approved, #7859
+maven/mavencentral/org.springframework.data/spring-data-rest-webmvc/4.0.4, Apache-2.0, approved, #7860
 maven/mavencentral/org.springframework.hateoas/spring-hateoas/2.0.3, Apache-2.0, approved, #7167
 maven/mavencentral/org.springframework.plugin/spring-plugin-core/3.0.0, Apache-2.0, approved, #7104
 maven/mavencentral/org.springframework.security/spring-security-config/6.0.2, Apache-2.0, approved, #7338
@@ -113,8 +113,8 @@ maven/mavencentral/org.springframework.security/spring-security-oauth2-core/6.0.
 maven/mavencentral/org.springframework.security/spring-security-oauth2-jose/6.0.2, Apache-2.0, approved, #7337
 maven/mavencentral/org.springframework.security/spring-security-rsa/1.0.11.RELEASE, Apache-2.0, approved, CQ20647
 maven/mavencentral/org.springframework.security/spring-security-web/6.0.2, Apache-2.0, approved, #7328
-maven/mavencentral/org.springframework.session/spring-session-core/3.0.1, , restricted, clearlydefined
-maven/mavencentral/org.springframework.session/spring-session-jdbc/3.0.1, , restricted, clearlydefined
+maven/mavencentral/org.springframework.session/spring-session-core/3.0.1, Apache-2.0, approved, #7858
+maven/mavencentral/org.springframework.session/spring-session-jdbc/3.0.1, Apache-2.0, approved, #7862
 maven/mavencentral/org.springframework/spring-aop/6.0.7, Apache-2.0, approved, #5940
 maven/mavencentral/org.springframework/spring-beans/6.0.7, Apache-2.0, approved, #5937
 maven/mavencentral/org.springframework/spring-context/6.0.7, Apache-2.0, approved, #5936

--- a/DEPENDENCIES_BACKEND
+++ b/DEPENDENCIES_BACKEND
@@ -1,12 +1,12 @@
-maven/mavencentral/ch.qos.logback/logback-classic/1.4.5, EPL-1.0 OR LGPL-2.1-only, approved, #3435
-maven/mavencentral/ch.qos.logback/logback-core/1.4.5, EPL-1.0 OR LGPL-2.1-only, approved, #3373
-maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.14.1, Apache-2.0, approved, #5303
-maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.14.1, Apache-2.0 AND MIT, approved, #4303
-maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.14.1, Apache-2.0, approved, #4105
-maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.14.1, Apache-2.0, approved, #5933
-maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.14.1, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.14.1, Apache-2.0, approved, #4699
-maven/mavencentral/com.fasterxml.jackson.module/jackson-module-parameter-names/2.14.1, Apache-2.0, approved, #5938
+maven/mavencentral/ch.qos.logback/logback-classic/1.4.6, EPL-1.0 OR LGPL-2.1-only, approved, #3435
+maven/mavencentral/ch.qos.logback/logback-core/1.4.6, EPL-1.0 OR LGPL-2.1-only, approved, #3373
+maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.14.2, Apache-2.0, approved, #5303
+maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.14.2, Apache-2.0 AND MIT, approved, #4303
+maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.14.2, Apache-2.0, approved, #4105
+maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.14.2, Apache-2.0, approved, #5933
+maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.14.2, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.14.2, Apache-2.0, approved, #4699
+maven/mavencentral/com.fasterxml.jackson.module/jackson-module-parameter-names/2.14.2, Apache-2.0, approved, #5938
 maven/mavencentral/com.github.stephenc.jcip/jcip-annotations/1.0-1, Apache-2.0, approved, CQ21949
 maven/mavencentral/com.google.code.findbugs/jsr305/3.0.2, Apache-2.0, approved, #20
 maven/mavencentral/com.google.code.gson/gson/2.10, Apache-2.0, approved, #6159
@@ -26,28 +26,28 @@ maven/mavencentral/commons-collections/commons-collections/3.2.2, Apache-2.0, ap
 maven/mavencentral/commons-lang/commons-lang/2.6, Apache-2.0, approved, CQ6183
 maven/mavencentral/commons-logging/commons-logging/1.2, Apache-2.0, approved, CQ10162
 maven/mavencentral/io.github.classgraph/classgraph/4.8.149, MIT, approved, CQ22530
-maven/mavencentral/io.micrometer/micrometer-commons/1.10.3, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #7333
-maven/mavencentral/io.micrometer/micrometer-observation/1.10.3, Apache-2.0, approved, #7331
-maven/mavencentral/io.netty/netty-buffer/4.1.87.Final, Apache-2.0, approved, CQ21842
-maven/mavencentral/io.netty/netty-codec-dns/4.1.87.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-codec-http/4.1.87.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-codec-http2/4.1.87.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-codec-socks/4.1.87.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-codec/4.1.87.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-common/4.1.87.Final, Apache-2.0 AND MIT AND CC0-1.0, approved, CQ21843
-maven/mavencentral/io.netty/netty-handler-proxy/4.1.87.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-handler/4.1.87.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-resolver-dns-classes-macos/4.1.87.Final, Apache-2.0, approved, #6367
-maven/mavencentral/io.netty/netty-resolver-dns-native-macos/4.1.87.Final, Apache-2.0, approved, #7004
-maven/mavencentral/io.netty/netty-resolver-dns/4.1.87.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-resolver/4.1.87.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-transport-classes-epoll/4.1.87.Final, Apache-2.0, approved, #6366
-maven/mavencentral/io.netty/netty-transport-native-epoll/4.1.87.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.87.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-transport/4.1.87.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.projectreactor.netty/reactor-netty-core/1.1.2, Apache-2.0, approved, #5946
-maven/mavencentral/io.projectreactor.netty/reactor-netty-http/1.1.2, Apache-2.0, approved, #6999
-maven/mavencentral/io.projectreactor/reactor-core/3.5.2, Apache-2.0, approved, #5934
+maven/mavencentral/io.micrometer/micrometer-commons/1.10.5, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #7333
+maven/mavencentral/io.micrometer/micrometer-observation/1.10.5, Apache-2.0, approved, #7331
+maven/mavencentral/io.netty/netty-buffer/4.1.90.Final, Apache-2.0, approved, CQ21842
+maven/mavencentral/io.netty/netty-codec-dns/4.1.90.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-codec-http/4.1.90.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-codec-http2/4.1.90.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-codec-socks/4.1.90.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-codec/4.1.90.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-common/4.1.90.Final, Apache-2.0 AND MIT AND CC0-1.0, approved, CQ21843
+maven/mavencentral/io.netty/netty-handler-proxy/4.1.90.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-handler/4.1.90.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-resolver-dns-classes-macos/4.1.90.Final, Apache-2.0, approved, #6367
+maven/mavencentral/io.netty/netty-resolver-dns-native-macos/4.1.90.Final, Apache-2.0, approved, #7004
+maven/mavencentral/io.netty/netty-resolver-dns/4.1.90.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-resolver/4.1.90.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-transport-classes-epoll/4.1.90.Final, Apache-2.0, approved, #6366
+maven/mavencentral/io.netty/netty-transport-native-epoll/4.1.90.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.90.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-transport/4.1.90.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.projectreactor.netty/reactor-netty-core/1.1.5, Apache-2.0, approved, #5946
+maven/mavencentral/io.projectreactor.netty/reactor-netty-http/1.1.5, Apache-2.0, approved, #6999
+maven/mavencentral/io.projectreactor/reactor-core/3.5.4, Apache-2.0, approved, #5934
 maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.7, Apache-2.0, approved, #5947
 maven/mavencentral/io.swagger.core.v3/swagger-core-jakarta/2.2.7, Apache-2.0, approved, #5929
 maven/mavencentral/io.swagger.core.v3/swagger-models-jakarta/2.2.7, Apache-2.0, approved, #5919
@@ -56,27 +56,27 @@ maven/mavencentral/jakarta.annotation/jakarta.annotation-api/2.1.1, EPL-2.0 OR G
 maven/mavencentral/jakarta.servlet/jakarta.servlet-api/6.0.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.servlet
 maven/mavencentral/jakarta.validation/jakarta.validation-api/3.0.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0, BSD-3-Clause, approved, ee4j.jaxb
-maven/mavencentral/net.minidev/accessors-smart/2.4.8, Apache-2.0, approved, #7515
-maven/mavencentral/net.minidev/json-smart/2.4.8, Apache-2.0, approved, #3288
+maven/mavencentral/net.minidev/accessors-smart/2.4.9, Apache-2.0, approved, #7515
+maven/mavencentral/net.minidev/json-smart/2.4.10, Apache-2.0, approved, #3288
 maven/mavencentral/org.apache.commons/commons-collections4/4.4, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-lang3/3.12.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-text/1.10.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.logging.log4j/log4j-api/2.19.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.logging.log4j/log4j-core/2.19.0, Apache-2.0 AND (Apache-2.0 AND LGPL-2.0-or-later), approved, #5009
 maven/mavencentral/org.apache.logging.log4j/log4j-to-slf4j/2.19.0, Apache-2.0, approved, #5941
-maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-core/10.1.5, Apache-2.0 AND (EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND (CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND W3C AND CC0-1.0, approved, #5949
-maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-el/10.1.5, Apache-2.0, approved, #6997
-maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-websocket/10.1.5, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-core/10.1.7, Apache-2.0 AND (EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND (CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND W3C AND CC0-1.0, approved, #5949
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-el/10.1.7, Apache-2.0, approved, #6997
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-websocket/10.1.7, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.atteo/evo-inflector/1.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.bouncycastle/bcpkix-jdk15on/1.69, MIT, approved, clearlydefined
 maven/mavencentral/org.bouncycastle/bcprov-jdk15on/1.69, MIT, approved, clearlydefined
 maven/mavencentral/org.bouncycastle/bcutil-jdk15on/1.69, MIT, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/3.12.0, MIT, approved, clearlydefined
 maven/mavencentral/org.codehaus.plexus/plexus-utils/3.2.1, , approved, CQ20774
-maven/mavencentral/org.ow2.asm/asm/9.1, BSD-3-Clause, approved, CQ23029
+maven/mavencentral/org.ow2.asm/asm/9.3, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/org.reactivestreams/reactive-streams/1.0.4, CC0-1.0, approved, CQ16332
-maven/mavencentral/org.slf4j/jul-to-slf4j/2.0.6, MIT, approved, #7698
-maven/mavencentral/org.slf4j/slf4j-api/2.0.6, MIT, approved, #5915
+maven/mavencentral/org.slf4j/jul-to-slf4j/2.0.7, MIT, approved, #7698
+maven/mavencentral/org.slf4j/slf4j-api/2.0.7, MIT, approved, #5915
 maven/mavencentral/org.sonarsource.scanner.api/sonar-scanner-api/2.16.2.588, LGPL-3.0-or-later, approved, #6945
 maven/mavencentral/org.sonarsource.scanner.maven/sonar-maven-plugin/3.9.1.2184, LGPL-3.0-or-later, approved, #6944
 maven/mavencentral/org.sonatype.plexus/plexus-cipher/1.4, Apache-2.0, approved, CQ4600
@@ -84,48 +84,48 @@ maven/mavencentral/org.sonatype.plexus/plexus-sec-dispatcher/1.4, Apache-2.0, ap
 maven/mavencentral/org.springdoc/springdoc-openapi-starter-common/2.0.2, Apache-2.0, approved, #5920
 maven/mavencentral/org.springdoc/springdoc-openapi-starter-webmvc-api/2.0.2, Apache-2.0, approved, #5950
 maven/mavencentral/org.springdoc/springdoc-openapi-starter-webmvc-ui/2.0.2, Apache-2.0, approved, #5923
-maven/mavencentral/org.springframework.boot/spring-boot-autoconfigure/3.0.2, Apache-2.0, approved, #6981
-maven/mavencentral/org.springframework.boot/spring-boot-starter-data-rest/3.0.2, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.springframework.boot/spring-boot-starter-json/3.0.2, Apache-2.0, approved, #7006
-maven/mavencentral/org.springframework.boot/spring-boot-starter-logging/3.0.2, Apache-2.0, approved, #6982
-maven/mavencentral/org.springframework.boot/spring-boot-starter-oauth2-client/3.0.2, Apache-2.0, approved, #5932
-maven/mavencentral/org.springframework.boot/spring-boot-starter-reactor-netty/3.0.2, Apache-2.0, approved, #6989
+maven/mavencentral/org.springframework.boot/spring-boot-autoconfigure/3.0.5, Apache-2.0, approved, #6981
+maven/mavencentral/org.springframework.boot/spring-boot-starter-data-rest/3.0.5, , restricted, clearlydefined
+maven/mavencentral/org.springframework.boot/spring-boot-starter-json/3.0.5, Apache-2.0, approved, #7006
+maven/mavencentral/org.springframework.boot/spring-boot-starter-logging/3.0.5, Apache-2.0, approved, #6982
+maven/mavencentral/org.springframework.boot/spring-boot-starter-oauth2-client/3.0.5, Apache-2.0, approved, #5932
+maven/mavencentral/org.springframework.boot/spring-boot-starter-reactor-netty/3.0.5, Apache-2.0, approved, #6989
 maven/mavencentral/org.springframework.boot/spring-boot-starter-security/3.0.2, Apache-2.0, approved, #7329
-maven/mavencentral/org.springframework.boot/spring-boot-starter-tomcat/3.0.2, Apache-2.0, approved, #6987
+maven/mavencentral/org.springframework.boot/spring-boot-starter-tomcat/3.0.5, Apache-2.0, approved, #6987
 maven/mavencentral/org.springframework.boot/spring-boot-starter-web/3.0.2, Apache-2.0, approved, #5945
-maven/mavencentral/org.springframework.boot/spring-boot-starter-webflux/3.0.2, Apache-2.0, approved, #6986
-maven/mavencentral/org.springframework.boot/spring-boot-starter/3.0.2, Apache-2.0, approved, #7330
-maven/mavencentral/org.springframework.boot/spring-boot/3.0.2, Apache-2.0, approved, #7327
+maven/mavencentral/org.springframework.boot/spring-boot-starter-webflux/3.0.5, Apache-2.0, approved, #6986
+maven/mavencentral/org.springframework.boot/spring-boot-starter/3.0.5, Apache-2.0, approved, #7330
+maven/mavencentral/org.springframework.boot/spring-boot/3.0.5, Apache-2.0, approved, #7327
 maven/mavencentral/org.springframework.cloud/spring-cloud-commons/3.1.5, Apache-2.0, approved, #4726
 maven/mavencentral/org.springframework.cloud/spring-cloud-context/3.1.5, Apache-2.0, approved, #4722
 maven/mavencentral/org.springframework.cloud/spring-cloud-starter-bootstrap/3.1.5, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.springframework.cloud/spring-cloud-starter/3.1.5, Apache-2.0, approved, #4723
-maven/mavencentral/org.springframework.data/spring-data-commons/3.0.1, Apache-2.0, approved, #5943
-maven/mavencentral/org.springframework.data/spring-data-rest-core/4.0.1, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.springframework.data/spring-data-rest-webmvc/4.0.1, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.springframework.hateoas/spring-hateoas/2.0.1, Apache-2.0, approved, #7167
+maven/mavencentral/org.springframework.data/spring-data-commons/3.0.4, Apache-2.0, approved, #5943
+maven/mavencentral/org.springframework.data/spring-data-rest-core/4.0.4, , restricted, clearlydefined
+maven/mavencentral/org.springframework.data/spring-data-rest-webmvc/4.0.4, , restricted, clearlydefined
+maven/mavencentral/org.springframework.hateoas/spring-hateoas/2.0.3, Apache-2.0, approved, #7167
 maven/mavencentral/org.springframework.plugin/spring-plugin-core/3.0.0, Apache-2.0, approved, #7104
-maven/mavencentral/org.springframework.security/spring-security-config/6.0.1, Apache-2.0, approved, #7338
-maven/mavencentral/org.springframework.security/spring-security-core/6.0.1, Apache-2.0, approved, #7325
-maven/mavencentral/org.springframework.security/spring-security-crypto/6.0.1, Apache-2.0 AND ISC, approved, #7326
-maven/mavencentral/org.springframework.security/spring-security-oauth2-client/6.0.1, Apache-2.0, approved, #5931
-maven/mavencentral/org.springframework.security/spring-security-oauth2-core/6.0.1, Apache-2.0, approved, #7324
-maven/mavencentral/org.springframework.security/spring-security-oauth2-jose/6.0.1, Apache-2.0, approved, #7337
+maven/mavencentral/org.springframework.security/spring-security-config/6.0.2, Apache-2.0, approved, #7338
+maven/mavencentral/org.springframework.security/spring-security-core/6.0.2, Apache-2.0, approved, #7325
+maven/mavencentral/org.springframework.security/spring-security-crypto/6.0.2, Apache-2.0 AND ISC, approved, #7326
+maven/mavencentral/org.springframework.security/spring-security-oauth2-client/6.0.2, Apache-2.0, approved, #5931
+maven/mavencentral/org.springframework.security/spring-security-oauth2-core/6.0.2, Apache-2.0, approved, #7324
+maven/mavencentral/org.springframework.security/spring-security-oauth2-jose/6.0.2, Apache-2.0, approved, #7337
 maven/mavencentral/org.springframework.security/spring-security-rsa/1.0.11.RELEASE, Apache-2.0, approved, CQ20647
-maven/mavencentral/org.springframework.security/spring-security-web/6.0.1, Apache-2.0, approved, #7328
-maven/mavencentral/org.springframework.session/spring-session-core/3.0.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.springframework.session/spring-session-jdbc/3.0.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.springframework/spring-aop/6.0.4, Apache-2.0, approved, #5940
-maven/mavencentral/org.springframework/spring-beans/6.0.4, Apache-2.0, approved, #5937
-maven/mavencentral/org.springframework/spring-context/6.0.4, Apache-2.0, approved, #5936
-maven/mavencentral/org.springframework/spring-core/6.0.4, Apache-2.0 AND BSD-3-Clause, approved, #5948
-maven/mavencentral/org.springframework/spring-expression/6.0.4, Apache-2.0, approved, #3284
-maven/mavencentral/org.springframework/spring-jcl/6.0.4, Apache-2.0, approved, #3283
-maven/mavencentral/org.springframework/spring-jdbc/6.0.4, Apache-2.0, approved, #5924
-maven/mavencentral/org.springframework/spring-tx/6.0.4, Apache-2.0, approved, #5926
-maven/mavencentral/org.springframework/spring-web/6.0.4, Apache-2.0, approved, #5942
-maven/mavencentral/org.springframework/spring-webflux/6.0.4, Apache-2.0, approved, #6964
-maven/mavencentral/org.springframework/spring-webmvc/6.0.4, Apache-2.0, approved, #5944
+maven/mavencentral/org.springframework.security/spring-security-web/6.0.2, Apache-2.0, approved, #7328
+maven/mavencentral/org.springframework.session/spring-session-core/3.0.1, , restricted, clearlydefined
+maven/mavencentral/org.springframework.session/spring-session-jdbc/3.0.1, , restricted, clearlydefined
+maven/mavencentral/org.springframework/spring-aop/6.0.7, Apache-2.0, approved, #5940
+maven/mavencentral/org.springframework/spring-beans/6.0.7, Apache-2.0, approved, #5937
+maven/mavencentral/org.springframework/spring-context/6.0.7, Apache-2.0, approved, #5936
+maven/mavencentral/org.springframework/spring-core/6.0.7, Apache-2.0 AND BSD-3-Clause, approved, #5948
+maven/mavencentral/org.springframework/spring-expression/6.0.7, Apache-2.0, approved, #3284
+maven/mavencentral/org.springframework/spring-jcl/6.0.7, Apache-2.0, approved, #3283
+maven/mavencentral/org.springframework/spring-jdbc/6.0.7, Apache-2.0, approved, #5924
+maven/mavencentral/org.springframework/spring-tx/6.0.7, Apache-2.0, approved, #5926
+maven/mavencentral/org.springframework/spring-web/6.0.7, Apache-2.0, approved, #5942
+maven/mavencentral/org.springframework/spring-webflux/6.0.7, Apache-2.0, approved, #6964
+maven/mavencentral/org.springframework/spring-webmvc/6.0.7, Apache-2.0, approved, #5944
 maven/mavencentral/org.webjars/swagger-ui/4.15.5, Apache-2.0 AND MIT, approved, #5921
 maven/mavencentral/org.webjars/webjars-locator-core/0.52, MIT, approved, clearlydefined
 maven/mavencentral/org.yaml/snakeyaml/2.0, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #7275

--- a/charts/consumer-backend/Chart.yaml
+++ b/charts/consumer-backend/Chart.yaml
@@ -37,10 +37,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.7
+version: 0.2.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.5.1"
+appVersion: "0.5.2"

--- a/charts/consumer-ui/Chart.yaml
+++ b/charts/consumer-ui/Chart.yaml
@@ -37,10 +37,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.7
+version: 0.2.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.5.1"
+appVersion: "0.5.2"

--- a/consumer-backend/productpass/pom.xml
+++ b/consumer-backend/productpass/pom.xml
@@ -28,12 +28,12 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.5</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.tractusx</groupId>
 	<artifactId>productpass</artifactId>
-	<version>0.4.0-SNAPSHOT</version>
+	<version>0.4.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 	<name>Catena-X Product Passport Consumer Backend</name>
 	<description>Product Passport Consumer Backend System for Product Passport Consumer Frontend Application</description>

--- a/consumer-backend/productpass/readme.md
+++ b/consumer-backend/productpass/readme.md
@@ -21,7 +21,7 @@
 -->
 
 # ![Digital Product Passport Consumer Backend](../../docs/catena-x-logo.svg) Product Battery Passport Consumer Backend
-# Version: 0.4.0-SNAPSHOT
+# Version: 0.4.1-SNAPSHOT
 
 ## Table of contents
 <!-- TOC -->

--- a/docs/RELEASE_USER.md
+++ b/docs/RELEASE_USER.md
@@ -22,6 +22,14 @@
 
 # Release Notes Digital Product Pass Application
 
+**April 13 2023 (Version 0.5.2)**  
+*13.04.2023*
+
+### Security Issues
+
+Updated Spring Boot Version from `v3.0.2` to `v3.0.5` in order to fix the security issues found in two libraries.
+
+
 **March 31 2023 (Version 0.5.1)**  
 *31.03.2023*
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "productpass-consumer-ui",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "productpass-consumer-ui",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
         "@mdi/font": "5.9.55",
         "@popperjs/core": "^2.11.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "productpass-consumer-ui",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "scripts": {
     "serve": "vite --host localhost",


### PR DESCRIPTION
# Why we create this PR?
In the day 11.04.2023 two vulnerabilities were detected by our team using Veracode. This vulnerabilities affect the released version `v0.5.1` from our application.

# What we want to achieve with this PR?
We want to fix the vulnerability in the backend so that the application becomes more safe

# What is new?
- Updated Spring Boot Version from `v3.0.2` to `v3.0.5` fixing the following vulnerable libraries:
  - Spring Expression *v6.0.4* -> `v6.0.7`
  - JSON Smart *v2.4.8* -> `v2.4.10`