### PR TITLE
Sub-Release 6: Release/v0.6.0: Updated and Added license headers

### DIFF
--- a/charts/consumer-backend/.helmignore
+++ b/charts/consumer-backend/.helmignore
@@ -1,24 +1,25 @@
-  /////////////////////////////////////////////////////////////////////////
-  // Catena-X - Product Passport Consumer Application
-  //
-  // Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
-  //
-  // See the NOTICE file(s) distributed with this work for additional
-  // information regarding copyright ownership.
-  //
-  // This program and the accompanying materials are made available under the
-  // terms of the Apache License, Version 2.0 which is available at
-  // https://www.apache.org/licenses/LICENSE-2.0.
-  //
-  // Unless required by applicable law or agreed to in writing, software
-  // distributed under the License is distributed on an "AS IS" BASIS
-  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-  // either express or implied. See the
-  // License for the specific language govern in permissions and limitations
-  // under the License.
-  //
-  // SPDX-License-Identifier: Apache-2.0
-  /////////////////////////////////////////////////////////////////////////
+#################################################################################
+# Catena-X - Product Passport Consumer Frontend
+#
+# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+##################################################################################
+
 
 # Patterns to ignore when building packages.
 # This supports shell glob matching, relative path matching, and

--- a/deployment/helm/edc-provider/data-service/.helmignore
+++ b/deployment/helm/edc-provider/data-service/.helmignore
@@ -1,3 +1,25 @@
+#################################################################################
+# Catena-X - Product Passport Consumer Frontend
+#
+# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+##################################################################################
+
 # Patterns to ignore when building packages.
 # This supports shell glob matching, relative path matching, and
 # negation (prefixed with !). Only one pattern per line.

--- a/deployment/helm/edc-provider/data-service/README.md
+++ b/deployment/helm/edc-provider/data-service/README.md
@@ -1,3 +1,25 @@
+<!--
+  Catena-X - Product Passport Consumer Application
+ 
+  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ 
+  See the NOTICE file(s) distributed with this work for additional
+  information regarding copyright ownership.
+ 
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0.
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+  either express or implied. See the
+  License for the specific language govern in permissions and limitations
+  under the License.
+ 
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 # backend-application
 
 ![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)

--- a/docs/IaC.md
+++ b/docs/IaC.md
@@ -1,3 +1,24 @@
+<!--
+  Catena-X - Product Passport Consumer Application
+ 
+  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ 
+  See the NOTICE file(s) distributed with this work for additional
+  information regarding copyright ownership.
+ 
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0.
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+  either express or implied. See the
+  License for the specific language govern in permissions and limitations
+  under the License.
+ 
+  SPDX-License-Identifier: Apache-2.0
+-->
 ## Infrastructure As Code (IaC) with KICS
 
 This tool intends to find security vulnerabilities by scanning the code  and upload results to the security dashboard in github. It is integrated as GitHub action into the repository workflows [KICS](../.github/workflows/kics.yml) and also a successor of Checkov. IaC must be scanned via nightly GitHub action and High/critical error findings are not accepted.

--- a/docs/SECRETS_MANAGEMENT.md
+++ b/docs/SECRETS_MANAGEMENT.md
@@ -1,3 +1,25 @@
+<!--
+  Catena-X - Product Passport Consumer Application
+ 
+  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ 
+  See the NOTICE file(s) distributed with this work for additional
+  information regarding copyright ownership.
+ 
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0.
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+  either express or implied. See the
+  License for the specific language govern in permissions and limitations
+  under the License.
+ 
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 ## Secrets management with CX HashiCorp Vault and ArgoCD Vault Plugin (AVP)
 
 The client credentials, database passwords, access tokens are considered as secrets and they are usually kept in a vault. CatenaX have a central Hashicorp vault component to store these types of secrets and credentails to prevant from revealing them in a public source code repository to ensure security. These secrets are then utilized by Kubernetes resources through helm charts in a safe and secure manner.

--- a/docs/admin guide/Admin_Guide.md
+++ b/docs/admin guide/Admin_Guide.md
@@ -1,3 +1,25 @@
+<!--
+  Catena-X - Product Passport Consumer Application
+ 
+  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ 
+  See the NOTICE file(s) distributed with this work for additional
+  information regarding copyright ownership.
+ 
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0.
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+  either express or implied. See the
+  License for the specific language govern in permissions and limitations
+  under the License.
+ 
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 # Product Passport Administrator Guide Documentation
 
 ![C-X Logo](./CXLogo.png)  
@@ -7,24 +29,34 @@ Latest Revision Mar 30, 2023
 
 ## Table of Contents
 
-1. [Table of contents](#table-of-contents)  
-2. [Introduction](#introduction)
-3. [Getting Started Guide](#getting-started-guide)
-4. [Deployment Configuration](#deployment-configuration)
-5. [Local Keycloak Configuration](#local-keycloak-configuration)
-6. [Helm Charts Configuration](#helm-charts-configuration)
-7. [Consumer Backend Configuration](#consumer-backend-configuration)  
-    7.1 [Backend Application Configuration](#backend-application-configuration)  
-    7.2  [Spring Boot Configuration](#spring-boot-configuration)  
-    7.3  [Spring Boot Logging Configuration](#spring-boot-logging-configuration)  
-8. [Postman Collection](#postman-collection)
-9. [Secrets Management](#secrets-management)
-10. [EDC Provider Configuration](#edc-provider-configuration)  
-    10.1 [Documentation Description](#documentation-description)    
-    10.2 [Asset Configuration](#asset-configuration)   
-    10.3 [Policies Configuration](#policies-configuration)    
-    10.4 [Contract Definition Configuration](#contract-definition-configuration)        
-    10.5 [Digital Twin Registration](#digital-twin-registration)
+- [Product Passport Administrator Guide Documentation](#product-passport-administrator-guide-documentation)
+  - [Table of Contents](#table-of-contents)
+  - [Introduction](#introduction)
+  - [Getting Started Guide](#getting-started-guide)
+  - [Deployment Configuration](#deployment-configuration)
+  - [Local Keycloak Configuration](#local-keycloak-configuration)
+  - [Helm Charts Configuration](#helm-charts-configuration)
+  - [Consumer Backend Configuration](#consumer-backend-configuration)
+    - [Backend Application Configuration](#backend-application-configuration)
+    - [Spring Boot Configuration](#spring-boot-configuration)
+    - [Spring Boot Logging Configuration](#spring-boot-logging-configuration)
+  - [Postman Collection](#postman-collection)
+  - [Secrets Management](#secrets-management)
+  - [EDC Provider Configuration](#edc-provider-configuration)
+    - [Documentation Description](#documentation-description)
+    - [Asset Configuration](#asset-configuration)
+      - [**Variables:**](#variables)
+      - [**Format and Fields:**](#format-and-fields)
+    - [Policies Configuration](#policies-configuration)
+      - [Usage Policies](#usage-policies)
+      - [**Variables:**](#variables-1)
+      - [**Format and Fields:**](#format-and-fields-1)
+    - [Contract Definition Configuration](#contract-definition-configuration)
+      - [**Variables:**](#variables-2)
+      - [**Format and Fields:**](#format-and-fields-2)
+    - [Digital Twin Registration](#digital-twin-registration)
+      - [**Variables:**](#variables-3)
+      - [**Format and Fields:**](#format-and-fields-3)
 ## Introduction
 
 This guide contains all the available information for an administrator to configure, operate and deploy the Product Passport Application.  

--- a/docs/business statement/Business Statement.md
+++ b/docs/business statement/Business Statement.md
@@ -1,3 +1,25 @@
+<!--
+  Catena-X - Product Passport Consumer Application
+ 
+  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ 
+  See the NOTICE file(s) distributed with this work for additional
+  information regarding copyright ownership.
+ 
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0.
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+  either express or implied. See the
+  License for the specific language govern in permissions and limitations
+  under the License.
+ 
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 # [MP] Product Passport Application
 
 >Some links might not be accesible as they lead to a private confluence. If you need access please reach out to the dev Team and request what information you need for what reason.

--- a/docs/cypress/CYPRESS.md
+++ b/docs/cypress/CYPRESS.md
@@ -1,3 +1,25 @@
+<!--
+  Catena-X - Product Passport Consumer Application
+ 
+  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ 
+  See the NOTICE file(s) distributed with this work for additional
+  information regarding copyright ownership.
+ 
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0.
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+  either express or implied. See the
+  License for the specific language govern in permissions and limitations
+  under the License.
+ 
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 # Cypress test
 
 This is the documentation for Battery Passport App E2E Cypress test.

--- a/docs/user manual/User Manual Product Viewer App.md
+++ b/docs/user manual/User Manual Product Viewer App.md
@@ -1,15 +1,38 @@
+<!--
+  Catena-X - Product Passport Consumer Application
+ 
+  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ 
+  See the NOTICE file(s) distributed with this work for additional
+  information regarding copyright ownership.
+ 
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0.
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+  either express or implied. See the
+  License for the specific language govern in permissions and limitations
+  under the License.
+ 
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 # User Manual
 
 This manual provides a step by step introduction on how to use the Product Pass Viewer app and gives an overview on its functionalities.
 
 ## Content
 
-1. [Content](#content)
-2. [Getting Started](#getting-started)
-3. [Main Menu](#main-menu)  
-4. [History Page](#history-page)
-5. [Search for Products](#search-for-products)
-6. [Results Page](#results-page)  
+- [User Manual](#user-manual)
+  - [Content](#content)
+  - [Getting Started](#getting-started)
+  - [Main Menu](#main-menu)
+  - [History Page](#history-page)
+  - [Search for Products](#search-for-products)
+  - [Results Page](#results-page)
 
 ## Getting Started
 

--- a/src/assets/styles/components/general/notFound.scss
+++ b/src/assets/styles/components/general/notFound.scss
@@ -1,19 +1,24 @@
 /**
- * Copyright 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- * 
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * 
- *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ * Catena-X - Product Passport Consumer Frontend
+ *
+ * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
  */
-
 .page-not-found {
     word-break: break-word;
     .title{

--- a/src/assets/styles/components/landing/searchView.scss
+++ b/src/assets/styles/components/landing/searchView.scss
@@ -1,3 +1,24 @@
+/**
+ * Catena-X - Product Passport Consumer Frontend
+ *
+ * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 .search-page {
   display: flex;
   flex-direction: column;

--- a/src/assets/styles/components/passport/cards.scss
+++ b/src/assets/styles/components/passport/cards.scss
@@ -1,3 +1,24 @@
+/**
+ * Catena-X - Product Passport Consumer Frontend
+ *
+ * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 .cards-container {
   margin-bottom: 24px;
   padding: 6px !important;

--- a/src/assets/styles/components/passport/elementChart.scss
+++ b/src/assets/styles/components/passport/elementChart.scss
@@ -1,3 +1,24 @@
+/**
+ * Catena-X - Product Passport Consumer Frontend
+ *
+ * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 .materials-container {
   width: 300px;
 }

--- a/src/assets/styles/components/passport/field.scss
+++ b/src/assets/styles/components/passport/field.scss
@@ -1,3 +1,24 @@
+/**
+ * Catena-X - Product Passport Consumer Frontend
+ *
+ * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 .field-container {
   position: relative;
   display: flex;

--- a/src/assets/styles/components/passport/passportPage.scss
+++ b/src/assets/styles/components/passport/passportPage.scss
@@ -1,3 +1,24 @@
+/**
+ * Catena-X - Product Passport Consumer Frontend
+ *
+ * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 .header-title {
   font-size: 16px;
   font-weight: 500;

--- a/src/components/general/ErrorComponent.vue
+++ b/src/components/general/ErrorComponent.vue
@@ -1,19 +1,24 @@
 <!--
- Copyright 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Catena-X - Product Passport Consumer Frontend
  
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
  
-     http://www.apache.org/licenses/LICENSE-2.0
+  See the NOTICE file(s) distributed with this work for additional
+  information regarding copyright ownership.
  
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0.
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+  either express or implied. See the
+  License for the specific language govern in permissions and limitations
+  under the License.
+ 
+  SPDX-License-Identifier: Apache-2.0
 -->
-
 
 
 <template>

--- a/src/components/passport/BarChart.vue
+++ b/src/components/passport/BarChart.vue
@@ -1,18 +1,25 @@
 <!--
- Copyright 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Catena-X - Product Passport Consumer Frontend
  
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
  
-     http://www.apache.org/licenses/LICENSE-2.0
+  See the NOTICE file(s) distributed with this work for additional
+  information regarding copyright ownership.
  
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0.
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+  either express or implied. See the
+  License for the specific language govern in permissions and limitations
+  under the License.
+ 
+  SPDX-License-Identifier: Apache-2.0
 -->
+
 
 
 <template>

--- a/src/components/passport/Cards.vue
+++ b/src/components/passport/Cards.vue
@@ -1,17 +1,23 @@
 <!--
- Copyright 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Catena-X - Product Passport Consumer Frontend
  
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
  
-     http://www.apache.org/licenses/LICENSE-2.0
+  See the NOTICE file(s) distributed with this work for additional
+  information regarding copyright ownership.
  
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0.
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+  either express or implied. See the
+  License for the specific language govern in permissions and limitations
+  under the License.
+ 
+  SPDX-License-Identifier: Apache-2.0
 -->
 
 

--- a/src/utils/threadUtil.js
+++ b/src/utils/threadUtil.js
@@ -1,26 +1,24 @@
-
-  /////////////////////////////////////////////////////////////////////////
-  // Catena-X - Product Passport Consumer Frontend
-  //
-  // Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
-  //
-  // See the NOTICE file(s) distributed with this work for additional
-  // information regarding copyright ownership.
-  //
-  // This program and the accompanying materials are made available under the
-  // terms of the Apache License, Version 2.0 which is available at
-  // https://www.apache.org/licenses/LICENSE-2.0.
-  //
-  // Unless required by applicable law or agreed to in writing, software
-  // distributed under the License is distributed on an "AS IS" BASIS
-  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-  // either express or implied. See the
-  // License for the specific language govern in permissions and limitations
-  // under the License.
-  //
-  // SPDX-License-Identifier: Apache-2.0
-  /////////////////////////////////////////////////////////////////////////
-
+/**
+ * Catena-X - Product Passport Consumer Frontend
+ *
+ * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 
 


### PR DESCRIPTION
Includes #16 (v0.6.0.0) + #17 (v0.6.0.1) + #18 (v0.6.0.2) + #19 (v0.6.0.3) + #20 (v0.6.0.4) + #21 (v0.6.0.5) + #24 (v0.6.0.6) 
= `v0.6.0`

# PR part of release v0.6.0, Sub Release v0.6.0.6

# Why we create this PR?

In the PR #16 there was detected that some license headers were missing or were incorrect.

# What we want to achieve with this PR?

This PR adds the fixes for that #16 PR, adding the missing license headers.

# What is new?

## Updated
- Updated pull request (PR) template description
- Upgrade battery pass test data for Passport Semantic version `v3.0.1`
- Adjusted footer and search components in consumer frontend
- Updated documentation for the digital product pass (Arc42 + Admin Guide)

## Deleted
- Removed history table from Dashboard page 

## Added
- Implemented new User Interface (UI) design for battery passport page
- Added digital product passport (DPP) logo and favicon icon for DPP frontend component 
- 404 and Error message in consumer backend handler
- Added null and none checks in the passport (improved stability)
  
## Issues Fixed
- Reference to the back button in consumer frontend
- Updated battery QR code styles
- Security vulnerabilities in veracode scanning tool
- Fixed swagger ui display api documentation
- Improved responsiveness from the application 

## Security Issues
- Fixed security vulnerabilities related to Spring Boot `v3.0.5` by upgrating to `v3.0.6`



