### PR TITLE
fix image name in docker frontend workflow

### DIFF
--- a/.github/workflows/publish-dpp-frontend-docker-image.yml
+++ b/.github/workflows/publish-dpp-frontend-docker-image.yml
@@ -126,7 +126,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: ${{ steps.meta.outputs.tags }}, ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.IMAGE_NAME }}:latest
+          tags: ${{ steps.meta.outputs.tags }}, ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}:latest
           labels: ${{ steps.meta.outputs.labels }}
 
       # https://github.com/peter-evans/dockerhub-description


### PR DESCRIPTION
# Why we create this PR?
 
**This PR is created for testing purposes to test publishing container images onto the docker.io.**

Following the PR https://github.com/eclipse-tractusx/digital-product-pass/pull/66. To fix the image name in publish-dpp-frontend-docker-image.yaml.

# What we want to achieve with this PR?
 
To grant public access to dpp container images on Docker Hub.
 
# What is new?
 
A new container registry where dpp container images are publicly accessible.

## PR Linked to:

https://github.com/eclipse-tractusx/digital-product-pass/pull/66

