### PR TITLE
Feature/docker-images fix image tags issue in container workflows

### DIFF
--- a/.github/workflows/publish-dpp-backend-docker-image.yml
+++ b/.github/workflows/publish-dpp-backend-docker-image.yml
@@ -29,7 +29,7 @@ name: "Publish Digital Product Pass Backend Docker Images"
 
 on:
   push:
-    branches: [ "main", "develop" ]
+    branches: [ "main", "develop", "feature/cmp-702/docker-images" ]
 
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
@@ -105,8 +105,8 @@ jobs:
         with:
           context: consumer-backend/productpass
           push: true
-          tags: ${{ steps.meta.outputs.tags }}, ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.IMAGE_NAME }}:latest
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta-for-ghcr.outputs.tags }}, ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.IMAGE_NAME }}:latest
+          labels: ${{ steps.meta-for-ghcr.outputs.labels }}
 
       # Build actions for docker hub registry
       - name: Docker meta for Docker Hub
@@ -152,8 +152,8 @@ jobs:
         with:
           context: consumer-backend/productpass
           push: true
-          tags: ${{ steps.meta.outputs.tags }}, ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}:latest
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta-for-dockerhub.outputs.tags }}, ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}:latest
+          labels: ${{ steps.meta-for-dockerhub.outputs.labels }}
 
       # https://github.com/peter-evans/dockerhub-description
       # Important step to push image description to DockerHub 

--- a/.github/workflows/publish-dpp-frontend-docker-image.yml
+++ b/.github/workflows/publish-dpp-frontend-docker-image.yml
@@ -29,7 +29,7 @@ name: "Publish Digital Product Pass Frontend Docker Images"
 
 on:
   push:
-    branches: [ "main", "develop" ]
+    branches: [ "main", "develop", "feature/cmp-702/docker-images" ]
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
@@ -91,8 +91,8 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: ${{ steps.meta.outputs.tags }}, ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.IMAGE_NAME }}:latest
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta-for-ghcr.outputs.tags }}, ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.IMAGE_NAME }}:latest
+          labels: ${{ steps.meta-for-ghcr.outputs.labels }}
 
       # Build actions for docker hub registry
       - name: Docker meta for Docker Hub
@@ -126,8 +126,8 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: ${{ steps.meta.outputs.tags }}, ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}:latest
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta-for-dockerhub.outputs.tags }}, ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}:latest
+          labels: ${{ steps.meta-for-dockerhub.outputs.labels }}
 
       # https://github.com/peter-evans/dockerhub-description
       # Important step to push image description to DockerHub 


### PR DESCRIPTION
# Why we create this PR?
 
**This PR is created for testing purposes to test publishing container images onto the docker.io.**

Following the PR https://github.com/eclipse-tractusx/digital-product-pass/pull/67. To fix the image tags in docker workflows.
 
# What we want to achieve with this PR?
 
To grant public access to dpp container images on Docker Hub.
 
# What is new?
 
A new container registry where dpp container images are publicly accessible.

## PR Linked to:
https://github.com/eclipse-tractusx/digital-product-pass/pull/67