### PR TITLE
Hotfix/v1.0.0-alpha: fixed infinite loop related to get status bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 - Commit ID and Repo URL added in frontend image
 - Frontend component to display legal information
 - Added components to display more contract information.
+- Fixed bug related to backend get status, where it looped over the status received.
 
 ## Updated
 - Updated charts configurations related to the backend.

--- a/charts/digital-product-pass/templates/service-frontend.yaml
+++ b/charts/digital-product-pass/templates/service-frontend.yaml
@@ -36,3 +36,4 @@ spec:
       name: http
   selector:
     {{- include "chart.selectorLabels" . | nindent 4 }}
+

--- a/src/components/general/Footer.vue
+++ b/src/components/general/Footer.vue
@@ -162,9 +162,9 @@ export default {
   computed: {
     tagRepoUrl() {
       if (VERSION == null || VERSION === "" || VERSION === "VERSION") {
-        return this.repoUrl;
+        return REPO_ENDPOINT;
       }
-      return this.repoUrl + "/releases/tag/v" + VERSION;
+      return REPO_ENDPOINT + "/releases/tag/v" + VERSION;
     },
   },
   setup() {

--- a/src/services/BackendService.js
+++ b/src/services/BackendService.js
@@ -91,14 +91,14 @@ export default class BackendService {
     while (retries < maxRetries) {
       statusResponse = await this.getStatus(processId, authentication)
       status = jsonUtil.get("data.status", statusResponse);
-      if (loopBreakStatus.includes(status) || status == null) {
+      if (loopBreakStatus.includes(status) || status == null || (jsonUtil.exists("history", status) && jsonUtil.exists("transfer-completed",status["history"]))) {
         break;
       }
       await threadUtil.sleep(waitingTime);
       retries++;
     }
 
-    if (status == "COMPLETED") {
+    if (status == "COMPLETED" || (jsonUtil.exists("history", status) && jsonUtil.exists("transfer-completed",status["history"]))) {
       return await this.retrievePassport(negotiation, authentication);
     }
 


### PR DESCRIPTION
This PR includes a little change in the charts so that a version gets created.
# Why we create this PR?

When the passport was requested from the frontend side sometimes the passport was not being retrieved since the passport was received but the status was not completed.
 
# What we want to achieve with this PR?

We want to fix the bug for including it in the release v1.0.0 updating the pre-release
 
# What is new?
 
## Added
- Fixed bug related to backend get status, where it looped over the status received.

