### PR TITLE
Hotfix/v1.0.0-alpha: fixed infinite loop related to get status bug

### DIFF
--- a/src/services/BackendService.js
+++ b/src/services/BackendService.js
@@ -82,7 +82,7 @@ export default class BackendService {
       )
     }
 
-    let loopBreakStatus = ["COMPLETED", "FAILED", "DECLINED"]
+    let loopBreakStatus = ["COMPLETED", "FAILED", "DECLINED", "RECEIVED"]
     let maxRetries = API_MAX_RETRIES;
     let waitingTime = API_DELAY;
     let retries = 0;
@@ -91,14 +91,14 @@ export default class BackendService {
     while (retries < maxRetries) {
       statusResponse = await this.getStatus(processId, authentication)
       status = jsonUtil.get("data.status", statusResponse);
-      if (loopBreakStatus.includes(status) || status == null || (jsonUtil.exists("history", status) && jsonUtil.exists("transfer-completed",status["history"]))) {
+      if (loopBreakStatus.includes(status) || status == null) {
         break;
       }
       await threadUtil.sleep(waitingTime);
       retries++;
     }
 
-    if (status == "COMPLETED" || (jsonUtil.exists("history", status) && jsonUtil.exists("transfer-completed",status["history"]))) {
+    if (status === "COMPLETED" || status === "RECEIVED" ) {
       return await this.retrievePassport(negotiation, authentication);
     }
 


### PR DESCRIPTION
This PR includes a little change in the charts so that a version gets created.
# Why we create this PR?

When the passport was requested from the frontend side sometimes the passport was not being retrieved since the passport was received but the status was not completed.
 
# What we want to achieve with this PR?

We want to fix the bug for including it in the release v1.0.0 updating the pre-release
 
# What is new?
 
## Added
- Fixed bug related to backend get status, where it looped over the status received.

