### PR TITLE
chore: added missing license header to test file

### DIFF
--- a/charts/digital-product-pass/templates/tests/test-dpp-connection.yaml
+++ b/charts/digital-product-pass/templates/tests/test-dpp-connection.yaml
@@ -1,3 +1,25 @@
+#################################################################################
+# Catena-X - Product Passport Consumer Application
+#
+# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
 apiVersion: v1
 kind: Pod
 metadata:


### PR DESCRIPTION
# Why we create this PR?
 
There was missing one licence header which was not detected in the previous PR of this branch.
 