### PR TITLE
Hotfix/v1.0.0-rc4: Changed exception to error at discovery service search in startup

### DIFF
--- a/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/listeners/AppListener.java
+++ b/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/listeners/AppListener.java
@@ -170,7 +170,20 @@ public class AppListener {
         LogUtil.printMessage("========= [ LOGGING STARTED ] ================================");
         LogUtil.printMessage("Creating log file...");
         if(!dtrConfig.getCentral()) {
-            catenaXService.start(); // Start the CatenaX service if the central attribute is set to false (we need the bpnDiscovery and edcDiscovery addresses)
+            Discovery discovery = catenaXService.start(); // Start the CatenaX service if the central attribute is set to false (we need the bpnDiscovery and edcDiscovery addresses)
+            if (discovery == null) {
+                LogUtil.printError("\n*************************************[CRITICAL ERROR]*************************************" +
+                        "\nIt was not possible to start the application correctly..." +
+                        "\nPlease configure the Discovery Service Endpoint property:" +
+                        "\n\t- [application.configuration.discovery.endpoint]" +
+                        "\nMake sure that the Technical User Credentials are correctly configured:" +
+                        "\n\t- [avp.helm.clientId]" +
+                        "\n\t- [avp.helm.clientSecret]" +
+                        "\nThis user should be able to retrieve the token from the following Keycloak Endpoint:" +
+                        "\n\t- [application.configuration.keycloak.tokenUri]" +
+                        "\n*****************************************************************************************\n"
+                );
+            }
         }
        }
 

--- a/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/services/CatenaXService.java
+++ b/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/services/CatenaXService.java
@@ -122,13 +122,14 @@ public class CatenaXService extends BaseService {
             Discovery discovery = this.getDiscoveryEndpoints();
             Boolean rs = this.updateDefaultDiscovery(discovery);
             if (!rs) {
-                LogUtil.printError("["this.getClass().getName() + "." + "start] Something went wrong when updating the discovery endpoints");
+                LogUtil.printError("["+this.getClass().getName() + "." + "start] Something went wrong when updating the discovery endpoints");
             }
             LogUtil.printMessage("[Catena-X Service] Retrieved and Stored the EDC & BPN Discovery endpoints!");
             return discovery;
         }catch(Exception e){
-            LogUtil.printError("["this.getClass().getName() + "." + "start] It was not possible to get the discovery endpoints");
+            LogUtil.printError("["+this.getClass().getName() + "." + "start] It was not possible to get the discovery endpoints");
         }
+        return null;
     }
     public Discovery addEndpoint(String key){
         try {

--- a/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/services/CatenaXService.java
+++ b/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/services/CatenaXService.java
@@ -122,14 +122,12 @@ public class CatenaXService extends BaseService {
             Discovery discovery = this.getDiscoveryEndpoints();
             Boolean rs = this.updateDefaultDiscovery(discovery);
             if (!rs) {
-                throw new ServiceException(this.getClass().getName(), "Something went wrong when updating the discovery endpoints");
+                LogUtil.printError("["this.getClass().getName() + "." + "start] Something went wrong when updating the discovery endpoints");
             }
             LogUtil.printMessage("[Catena-X Service] Retrieved and Stored the EDC & BPN Discovery endpoints!");
             return discovery;
         }catch(Exception e){
-            throw new ServiceException(this.getClass().getName() + "." + "start",
-                    e,
-                    "It was not possible to get the discovery endpoints");
+            LogUtil.printError("["this.getClass().getName() + "." + "start] It was not possible to get the discovery endpoints");
         }
     }
     public Discovery addEndpoint(String key){


### PR DESCRIPTION
# Why we create this PR?
 
There is a requirement in the TRG 5.01 what all the application components should be deployed without any problem.
And our application is on startup calling a the Discovery Service from Catena-X and giving an exception. This needs to be fixed.
Issue documented here #122 
 
# What we want to achieve with this PR?
 
We want to change the exception to an simple log error to fix the issue.
 
# What is new?
 
## Updated
- Changed exception from Discovery Service startup to an Critical Error message
