### PR TITLE
Hotfix/v1.0.0 docs trivy: add Notice in docs and fix trivy workflow

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -43,6 +43,7 @@ on:
 
 env:
   REGISTRY: 'ghcr.io'
+  IMAGE_NAMESPACE: 'tractusx'
   FRONTEND_IMAGE_NAME: "digital-product-pass-frontend"
   BACKEND_IMAGE_NAME: "digital-product-pass-backend"
   JAVA_VERSION: 19
@@ -88,14 +89,36 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Build frontend image from Dockerfile
+      - name: Build frontend image from Dockerfile - GHCR
+        id: build-docker-frontend-ghcr
+        if: ${{ github.repository != 'eclipse-tractusx/digital-product-pass' }}
         run: docker build -t ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.FRONTEND_IMAGE_NAME }}:latest .
 
-      - name: Run Trivy vulnerability scanner
-        if: always()
+        # Build action for docker hub registry
+      - name: Build frontend image from Dockerfile - Docker Hub
+        id: build-docker-frontend-dockerhub
+        if: ${{ github.repository == 'eclipse-tractusx/digital-product-pass' }}
+        run: docker build -t ${{ env.IMAGE_NAMESPACE }}/${{ env.FRONTEND_IMAGE_NAME }}:latest .
+
+      - name: Run Trivy vulnerability scanner - GHCR
+        id: run-trivy-vulnerability-scanner-frontend-ghcr
+        if: ${{ github.repository != 'eclipse-tractusx/digital-product-pass' }}
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: "${{ env.REGISTRY }}/${{ github.repository }}/${{ env.FRONTEND_IMAGE_NAME }}"
+          format: "sarif"
+          output: "trivy-results-dpp-frontend.sarif"
+          exit-code: "1"
+          hide-progress: false
+          severity: "CRITICAL,HIGH"
+      
+      # Build action for docker hub registry
+      - name: Run Trivy vulnerability scanner - Docker Hub
+        id: run-trivy-vulnerability-scanner-frontend-dockerhub
+        if: ${{ github.repository == 'eclipse-tractusx/digital-product-pass' }}
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: "${{ env.IMAGE_NAMESPACE }}/${{ env.FRONTEND_IMAGE_NAME }}"
           format: "sarif"
           output: "trivy-results-dpp-frontend.sarif"
           exit-code: "1"
@@ -130,16 +153,40 @@ jobs:
           cd consumer-backend/productpass
           mvn -B clean install
 
-      - name: Build backend image from Dockerfile
+      - name: Build backend image from Dockerfile - GHCR
+        id: build-docker-backend-ghcr
+        if: ${{ github.repository != 'eclipse-tractusx/digital-product-pass' }}
         run: |
           cd consumer-backend/productpass
           docker build -t ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.BACKEND_IMAGE_NAME }}:latest .
 
-      - name: Run Trivy vulnerability scanner
-        if: always()
+        # Build action for docker hub registry
+      - name: Build backend image from Dockerfile - Docker Hub
+        id: build-docker-backend-dockerhub
+        if: ${{ github.repository == 'eclipse-tractusx/digital-product-pass' }}
+        run: |
+          cd consumer-backend/productpass
+          docker build -t ${{ env.IMAGE_NAMESPACE }}/${{ env.BACKEND_IMAGE_NAME }}:latest .
+
+      - name: Run Trivy vulnerability scanner - GHCR
+        id: run-trivy-vulnerability-scanner-backend-ghcr
+        if: ${{ github.repository != 'eclipse-tractusx/digital-product-pass' }}
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: "${{ env.REGISTRY }}/${{ github.repository }}/${{ env.BACKEND_IMAGE_NAME }}"
+          format: "sarif"
+          output: "trivy-results-dpp-backend.sarif"
+          exit-code: "1"
+          hide-progress: false
+          severity: "CRITICAL,HIGH"
+
+        # Build action for docker hub registry
+      - name: Run Trivy vulnerability scanner - Docker Hub
+        id: run-trivy-vulnerability-scanner-backend-dockerhub
+        if: ${{ github.repository == 'eclipse-tractusx/digital-product-pass' }}
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: "${{ env.IMAGE_NAMESPACE }}/${{ env.BACKEND_IMAGE_NAME }}"
           format: "sarif"
           output: "trivy-results-dpp-backend.sarif"
           exit-code: "1"

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -131,7 +131,9 @@ jobs:
           mvn -B clean install
 
       - name: Build backend image from Dockerfile
-        run: docker build -t ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.BACKEND_IMAGE_NAME }}:latest -f ./consumer-backend/productpass/Dockerfile .
+        run: |
+          cd consumer-backend/productpass
+          docker build -t ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.BACKEND_IMAGE_NAME }}:latest .
 
       - name: Run Trivy vulnerability scanner
         if: always()

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -42,6 +42,7 @@ on:
           type: string
 
 env:
+  REGISTRY: 'ghcr.io'
   FRONTEND_IMAGE_NAME: "digital-product-pass-frontend"
   BACKEND_IMAGE_NAME: "digital-product-pass-backend"
   JAVA_VERSION: 19
@@ -88,13 +89,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build frontend image from Dockerfile
-        run: docker build -t ${{ env.FRONTEND_IMAGE_NAME }}:${{ github.sha }} .
+        run: docker build -t ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.FRONTEND_IMAGE_NAME }}:latest .
 
       - name: Run Trivy vulnerability scanner
         if: always()
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: "${{ env.FRONTEND_IMAGE_NAME }}"
+          image-ref: "${{ env.REGISTRY }}/${{ github.repository }}/${{ env.FRONTEND_IMAGE_NAME }}"
           format: "sarif"
           output: "trivy-results-dpp-frontend.sarif"
           exit-code: "1"
@@ -130,13 +131,13 @@ jobs:
           mvn -B clean install
 
       - name: Build backend image from Dockerfile
-        run: docker build -t ${{ env.BACKEND_IMAGE_NAME }}:${{ github.sha }} -f ./consumer-backend/productpass/Dockerfile .
+        run: docker build -t ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.BACKEND_IMAGE_NAME }}:latest -f ./consumer-backend/productpass/Dockerfile .
 
       - name: Run Trivy vulnerability scanner
         if: always()
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: "${{ env.BACKEND_IMAGE_NAME }}"
+          image-ref: "${{ env.REGISTRY }}/${{ github.repository }}/${{ env.BACKEND_IMAGE_NAME }}"
           format: "sarif"
           output: "trivy-results-dpp-backend.sarif"
           exit-code: "1"

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -25,45 +25,127 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-name: Security scan with Trivy
+name: "Trivy"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "hotfix/v1.0.0-rc4" ]
   schedule:
     - cron: "0 0 * * *"
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: "consumer-ui"
+  workflow_dispatch:
+      inputs:
+        branch:
+          description: "Branch to use"
+          required: true
+          default: "main"
+          type: string
 
-permissions:
-  contents: read
+env:
+  FRONTEND_IMAGE_NAME: "digital-product-pass-frontend"
+  BACKEND_IMAGE_NAME: "digital-product-pass-backend"
+  JAVA_VERSION: 19
 
 jobs:
-  build:
-    permissions:
-      contents: read # for actions/checkout to fetch code
-      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-    name: Build
+  analyze-config:
     runs-on: "ubuntu-latest"
+    permissions:
+      actions: read
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results 
+
     steps:
-      - name: Checkout code
+      - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Build an image from Dockerfile
-        run: docker build -t ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.IMAGE_NAME }}:${{ github.sha }} .
-
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@7b7aa264d83dc58691451798b4d117d53d21edfe
+      - name: Run Trivy vulnerability scanner in repo mode
+        uses: aquasecurity/trivy-action@master
         with:
-          image-ref: '${{ env.REGISTRY }}/${{ github.repository }}/${{ env.IMAGE_NAME }}:${{ github.sha }}'
-          format: 'template'
-          template: '@/contrib/sarif.tpl'
-          output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH'
+          scan-type: "config"
+          # ignore-unfixed: true
+          exit-code: "1"
+          hide-progress: false
+          # image-ref: "${{ env.REGISTRY }}/${{ github.repository }}/${{ env.IMAGE_NAME }}:${{ github.sha }}"
+          format: "sarif"
+          output: "trivy-results1.sarif"
+          severity: "CRITICAL,HIGH"
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
+        if: always()
         with:
-          sarif_file: 'trivy-results.sarif'
+          sarif_file: "trivy-results1.sarif"
+
+  analyze-digital-product-pass-frontend:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Build frontend image from Dockerfile
+        run: docker build -t ${{ env.FRONTEND_IMAGE_NAME }}:${{ github.sha }} .
+
+      - name: Run Trivy vulnerability scanner
+        if: always()
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: "${{ env.FRONTEND_IMAGE_NAME }}"
+          format: "sarif"
+          output: "trivy-results-dpp-frontend.sarif"
+          exit-code: "1"
+          hide-progress: false
+          severity: "CRITICAL,HIGH"
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: "trivy-results-dpp-frontend.sarif"
+
+  analyze-digital-product-pass-backend:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-java@v3
+        with:
+          java-version: "${{ env.JAVA_VERSION }}"
+          distribution: "temurin"
+          
+      # Build Java code with Maven
+      - name: Build JAR
+        run: |
+          cd consumer-backend/productpass
+          mvn -B clean install
+
+      - name: Build backend image from Dockerfile
+        run: docker build -t ${{ env.BACKEND_IMAGE_NAME }}:${{ github.sha }} -f ./consumer-backend/productpass/Dockerfile .
+
+      - name: Run Trivy vulnerability scanner
+        if: always()
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: "${{ env.BACKEND_IMAGE_NAME }}"
+          format: "sarif"
+          output: "trivy-results-dpp-backend.sarif"
+          exit-code: "1"
+          hide-progress: false
+          severity: "CRITICAL,HIGH"
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: "trivy-results-dpp-backend.sarif"
+

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -29,7 +29,7 @@ name: "Trivy"
 
 on:
   push:
-    branches: [ "main", "hotfix/v1.0.0-rc4" ]
+    branches: [ "main" ]
   schedule:
     - cron: "0 0 * * *"
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -258,3 +258,13 @@ _integration_ (`https://materialpass.int.demo.catena-x.net/`) environments.
 
 - [Documentation of EDC Data Transfer](https://github.com/eclipse-tractusx/tractusx-edc/blob/main/docs/samples/Transfer%20Data.md)
 - [End-to-End Use Case](https://catenax-ng.github.io/docs/guides/catenax-at-home#end-to-end-use-case)
+
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+- SPDX-FileCopyrightText: 2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/digital-product-pass

--- a/docs/IaC.md
+++ b/docs/IaC.md
@@ -65,3 +65,13 @@ It performs code analysis in the pipeline, show results and feedback once pipeli
 It builds, package up the code and upload results to the [veracode platform](https://analysiscenter.veracode.com). It is one of the important jobs, and must be aligned to the quality gate requirements. 
 
 Please see more details about Veracode tool integration [here](https://catenax-ng.github.io/docs/security/how-to-integrate-veracode).
+
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+- SPDX-FileCopyrightText: 2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/digital-product-pass

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -44,3 +44,13 @@ Aditional Helm charts of below components can be found in *deployment/helm* fold
 In order to update helm charts, please update helm chart version and related dependencies from *version* property in *Chart.yaml file* for the above components. In addition, if there are changes to application version, the *appVersion* property also needs to be changed.
 
 Navigate to the [Deploymment Guide](/deployment/README.md) and follow the steps. The deployment guide illustrates the manual steps to install helm deployments into ArgoCD INT environment.
+
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+- SPDX-FileCopyrightText: 2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/digital-product-pass

--- a/docs/RELEASE_USER.md
+++ b/docs/RELEASE_USER.md
@@ -282,3 +282,13 @@ For a fast and efficient overview, a table containing the technical product info
 #### Additional insights
 
 A deep dive on the application's operation and functionalities can be found in the [End User Manual](docs\user%20manual\User%20Manual%20Product%20Viewer%20App.md).
+
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+- SPDX-FileCopyrightText: 2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/digital-product-pass

--- a/docs/SECRETS_MANAGEMENT.md
+++ b/docs/SECRETS_MANAGEMENT.md
@@ -114,3 +114,13 @@ The git hooks for this repository are set up in [yaml file](../pre-commit-config
 
 
 Setting up Git Guradian for the project [gitguardian-shield](https://docs.gitguardian.com/ggshield-docs/getting-started)
+
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+- SPDX-FileCopyrightText: 2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/digital-product-pass

--- a/docs/admin guide/Admin_Guide.md
+++ b/docs/admin guide/Admin_Guide.md
@@ -48,6 +48,7 @@ Latest Revision Mar 30, 2023
     10.3 [Policies Configuration](#policies-configuration)    
     10.4 [Contract Definition Configuration](#contract-definition-configuration)        
     10.5 [Digital Twin Registration](#digital-twin-registration)
+11. [NOTICE](#notice)
 
 ## Introduction
 

--- a/docs/admin guide/Admin_Guide.md
+++ b/docs/admin guide/Admin_Guide.md
@@ -405,3 +405,12 @@ Once you finish the configuration, to make the endpoint public configure in the 
 *The BPN number is not required for the configuration of the endpoint, just **make sure that the host is pointing to the EDC Provider**.*
 
 
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+- SPDX-FileCopyrightText: 2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/digital-product-pass
+

--- a/docs/arc42/Arc42.md
+++ b/docs/arc42/Arc42.md
@@ -86,6 +86,7 @@ Latest Revision: Aug. 11, 2023
     - [Quality Scenarios](#quality-scenarios)
   - [Risks and Technical Debts](#risks-and-technical-debts)
   - [Glossary](#glossary)
+  - [NOTICE](#notice)
 
 ## Introduction and Goals
 

--- a/docs/arc42/Arc42.md
+++ b/docs/arc42/Arc42.md
@@ -548,3 +548,13 @@ An user needs to be able to understand easily the application interface, in orde
 | Git | Is a distributed version control system: tracking changes in any set of files, usually used for coordinating work among programmers collaboratively developing source code during software development. |
 | DevOps | Is a set of practices that combines software development (Dev) and IT operations (Ops). It aims to shorten the systems development life cycle and provide continuous delivery with high software quality. |
 | Repository | Is a database of digital content with an associated set of data management, search and access methods allowing application-independent access to the content, rather like a digital library, but with the ability to store and modify content in addition to searching and retrieving. |
+
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+- SPDX-FileCopyrightText: 2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/digital-product-pass

--- a/docs/business statement/Business Statement.md
+++ b/docs/business statement/Business Statement.md
@@ -80,3 +80,13 @@ The following candidates are not yet implemented:
 * Gearbox Passport
 * Sealant Passport, Tire Passport
 * Generic Product Passport
+
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+- SPDX-FileCopyrightText: 2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/digital-product-pass

--- a/docs/cypress/CYPRESS.md
+++ b/docs/cypress/CYPRESS.md
@@ -47,3 +47,13 @@ This is the documentation for Battery Passport App E2E Cypress test.
 
 ![test](./test.png)  
 </br></br>
+
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+- SPDX-FileCopyrightText: 2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/digital-product-pass

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -45,6 +45,7 @@ Welcome to the documentation section, below you will find all the necesary docs 
 - [API Documentation](#api-documentation)
   - [Postman Collection](#postman-collection)
   - [Swagger Documetation](#swagger-documetation)
+- [NOTICE](#notice)
 <!-- TOC -->
 
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -198,3 +198,13 @@ You can also deploy the application using the [deployment guidelines](./GETTING-
 </pre>
 
 > **Note**: The port can vary if you change the port at the configuration.
+
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+- SPDX-FileCopyrightText: 2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/digital-product-pass

--- a/docs/user manual/User Manual Product Viewer App.md
+++ b/docs/user manual/User Manual Product Viewer App.md
@@ -32,7 +32,8 @@ This manual provides a step by step introduction on how to use the Product Pass 
     1. [Product Search](#search-for-a-product-passport)
     2. [Profile Information and Settings](#settings-and-profile-information)
     3. [Catena-X Helpdesk](#catena-x-helpdesk)
-4. [Results Page](#results-page)  
+4. [Results Page](#results-page)
+5. [NOTICE](#notice)
 
 ## Getting Started
 

--- a/docs/user manual/User Manual Product Viewer App.md
+++ b/docs/user manual/User Manual Product Viewer App.md
@@ -96,3 +96,13 @@ Hereby, the information is devided into the following sections:
 7. Data exchange Information
 
 Each category can be accessed by clicking on its heading in the selection bar towards the middle of the product passport screen (7).
+
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+- SPDX-FileCopyrightText: 2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/digital-product-pass


### PR DESCRIPTION
# Why we create this PR?
 
This PR contains the following hotfix changes:
- Added notice section to readme files in docs folder
- Fix trivy workflow to support scanning of latest docker images 

# What we want to achieve with this PR?
- Added notice section to docs in order to fulfill the [TRG 7.07](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-07/#documentation) requirement
- Fix trivy workflow to support latest container images for QGs approval.
  
This PR relates to the following GitHub issues:
- https://github.com/eclipse-tractusx/digital-product-pass/issues/108#issuecomment-1683608930
- https://github.com/eclipse-tractusx/digital-product-pass/issues/60
# What is new?
 
## Added
- Added a NOTICE section to readme files in docs

## Issues Fixed
- Fix issues in trivy workflow file