### PR TITLE
[1º] - Hotfix/v1.3.1-discovery-service: Fixed timeout issue with inexistent BPN and EDC Discoveries listed in the "Discovery Service"

### DIFF
--- a/charts/digital-product-pass/values-beta.yaml
+++ b/charts/digital-product-pass/values-beta.yaml
@@ -158,9 +158,10 @@ backend:
           bpn:
             key: "manufacturerPartId"
             searchPath: "/api/v1.0/administration/connectors/bpnDiscovery/search"
+            timeout: 2000
           edc:
             key: "bpn"
-      
+            timeout: 2000
       
         process:
           store: true

--- a/charts/digital-product-pass/values-dev.yaml
+++ b/charts/digital-product-pass/values-dev.yaml
@@ -158,9 +158,10 @@ backend:
           bpn:
             key: "manufacturerPartId"
             searchPath: "/api/v1.0/administration/connectors/bpnDiscovery/search"
+            timeout: 2000
           edc:
             key: "bpn"
-      
+            timeout: 2000
       
         process:
           store: true

--- a/charts/digital-product-pass/values-int.yaml
+++ b/charts/digital-product-pass/values-int.yaml
@@ -157,8 +157,10 @@ backend:
           bpn:
             key: "manufacturerPartId"
             searchPath: "/api/v1.0/administration/connectors/bpnDiscovery/search"
+            timeout: 2000
           edc:
             key: "bpn"
+            timeout: 2000
       
       
         process:

--- a/charts/digital-product-pass/values.yaml
+++ b/charts/digital-product-pass/values.yaml
@@ -190,9 +190,11 @@ backend:
           bpn:
             key: "manufacturerPartId"
             searchPath: "/api/v1.0/administration/connectors/bpnDiscovery/search"
+            timeout: 2000  # -- timeout in milliseconds for the bpn discovery APIs to respond
           # -- edc discovery configuration
           edc:
             key: "bpn"
+            timeout: 2000 # -- timeout in milliseconds for the bpn discovery APIs to respond
         # -- process configuration
         process:
           # -- directory for storing the contract negotiation files

--- a/consumer-backend/productpass/pom.xml
+++ b/consumer-backend/productpass/pom.xml
@@ -33,7 +33,7 @@
     </parent>
     <groupId>org.eclipse.tractusx</groupId>
     <artifactId>productpass</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
     <packaging>jar</packaging>
     <name>Catena-X Digital Product Passport Backend</name>
     <description>Product Passport Consumer Backend System for Product Passport Consumer Frontend Application

--- a/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/config/DiscoveryConfig.java
+++ b/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/config/DiscoveryConfig.java
@@ -72,6 +72,8 @@ public class DiscoveryConfig {
         String key;
         String searchPath;
 
+        Integer timeout;
+
         /** GETTERS AND SETTERS **/
         public String getKey() {
             return key;
@@ -86,6 +88,14 @@ public class DiscoveryConfig {
         public void setSearchPath(String searchPath) {
             this.searchPath = searchPath;
         }
+
+        public Integer getTimeout() {
+            return timeout;
+        }
+
+        public void setTimeout(Integer timeout) {
+            this.timeout = timeout;
+        }
     }
 
     /**
@@ -96,12 +106,20 @@ public class DiscoveryConfig {
         /** ATTRIBUTES **/
         String key;
 
+        Integer timeout;
         /** GETTERS AND SETTERS **/
         public String getKey() {
             return key;
         }
         public void setKey(String key) {
             this.key = key;
+        }
+        public Integer getTimeout() {
+            return timeout;
+        }
+
+        public void setTimeout(Integer timeout) {
+            this.timeout = timeout;
         }
     }
 

--- a/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/services/CatenaXService.java
+++ b/consumer-backend/productpass/src/main/java/org/eclipse/tractusx/productpass/services/CatenaXService.java
@@ -505,6 +505,7 @@ public class CatenaXService extends BaseService {
             if (edcEndpoints == null) {
                 throw new ServiceException(this.getClass().getName() + ".getEdcDiscovery", "The edc discovery endpoint is empty!");
             }
+            Integer timeout = discoveryConfig.getEdc().getTimeout();
             List<EdcDiscoveryEndpoint> edcDiscoveryResponses = new ArrayList<>();
             for(String edcEndpoint : edcEndpoints) {
 
@@ -512,7 +513,7 @@ public class CatenaXService extends BaseService {
                 HttpHeaders headers = httpUtil.getHeadersWithToken(this.authService.getToken().getAccessToken());
                 headers.add("Content-Type", "application/json");
                 try{
-                    ResponseEntity<?> response = httpUtil.doPost(edcEndpoint, JsonNode.class, headers, httpUtil.getParams(), bpns, false, false);
+                    ResponseEntity<?> response = httpUtil.doPost(edcEndpoint, JsonNode.class, headers, httpUtil.getParams(), bpns, false, false, timeout);
                     JsonNode result = (JsonNode) response.getBody();
                     List<EdcDiscoveryEndpoint> edcDiscoveryResponse = (List<EdcDiscoveryEndpoint>) jsonUtil.bindJsonNode(result, List.class);
                     if(edcDiscoveryResponse.isEmpty()) {
@@ -567,6 +568,7 @@ public class CatenaXService extends BaseService {
             if(bpnEndpoints == null){
                 throw new ServiceException(this.getClass().getName() + ".getBpnDiscovery", "The bpn discovery endpoint is empty!");
             }
+            Integer timeout = discoveryConfig.getBpn().getTimeout(); // Get timeout in configuration for the bpn discovery endpoints
             List<BpnDiscovery> bpnDiscoveryResponse = new ArrayList<>();
             for(String bpnEndpoint : bpnEndpoints) {
 
@@ -585,7 +587,7 @@ public class CatenaXService extends BaseService {
                 HttpHeaders headers = httpUtil.getHeadersWithToken(this.authService.getToken().getAccessToken());
                 headers.add("Content-Type", "application/json");
                 try{
-                    ResponseEntity<?> response = httpUtil.doPost(searchEndpoint, JsonNode.class, headers, httpUtil.getParams(), body, false, false);
+                    ResponseEntity<?> response = httpUtil.doPost(searchEndpoint, JsonNode.class, headers, httpUtil.getParams(), body, false, false, timeout);
                     JsonNode result = (JsonNode) response.getBody();
                     BpnDiscovery bpnDiscovery = (BpnDiscovery) jsonUtil.bindJsonNode(result, BpnDiscovery.class);
                     if(bpnDiscovery == null){
@@ -595,6 +597,7 @@ public class CatenaXService extends BaseService {
                     bpnDiscoveryResponse.add(bpnDiscovery);
                 }catch (Exception e){
                     LogUtil.printException(e, "BPN Number not found for ["+searchEndpoint+"] and keyType ["+type+"]!");
+                    break;
                 }
             }
             if(bpnDiscoveryResponse.isEmpty()){

--- a/consumer-backend/productpass/src/main/java/utils/ThreadUtil.java
+++ b/consumer-backend/productpass/src/main/java/utils/ThreadUtil.java
@@ -23,12 +23,11 @@
 
 package utils;
 
+import utils.exceptions.UtilException;
+
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.*;
 
 /**
  * This class consists exclusively of methods to operate on a Thread level.
@@ -121,5 +120,33 @@ public final class ThreadUtil {
             Thread.currentThread().interrupt();
         }
     }
-
+    /**
+     * Puts the scheduled thread in the runtime that this method is called to sleep for a given time.
+     * <p>
+     * Note: In case of an exception, the thread put to sleep is interrupted.
+     * <p>
+     * @param   milliseconds
+     *          the length of time to sleep in milliseconds.
+     */
+    public static <V> V timeout(Integer milliseconds, Callable<V> function, V timeoutResponse)
+    {
+        try {
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            Future<V> future = executor.submit(function);
+            boolean timeout = false;
+            V returnObject = null;
+            try {
+                returnObject = future.get(milliseconds, TimeUnit.MILLISECONDS);
+            } catch (TimeoutException e) {
+                timeout = true;
+            }
+            executor.shutdownNow();
+            if(timeout){
+                return timeoutResponse;
+            }
+            return returnObject;
+        } catch (Exception e) {
+            throw new UtilException(ThreadUtil.class, e, "Failed to execute the timeout functions!");
+        }
+    }
 }

--- a/consumer-backend/productpass/src/main/resources/application.yml
+++ b/consumer-backend/productpass/src/main/resources/application.yml
@@ -95,8 +95,10 @@ configuration:
     bpn:
       key: "manufacturerPartId"
       searchPath: "/api/v1.0/administration/connectors/bpnDiscovery/search"
+      timeout: 2000
     edc:
       key: "bpn"
+      timeout: 2000
 
 
   process:


### PR DESCRIPTION
# Why we create this PR?
There is the need to fix a bug related to the BPN and EDC Discovery when the APIs configured there dont exist.
 
# What we want to achieve with this PR?
 
We want to solve the problem by introducing a configurable timeout in the calls.
 
# What is new?
 
## Added
- Added timeout for the `BPN Discovery` and `EDC Discovery`  APIs returned in the Discovery Service API

