### PR TITLE
[ 11º ] - Feature/swaggerhub workflow: Prepared workflow to host backend API specs to the central swaggerhub

### DIFF
--- a/.github/actions/setup-java/action.yaml
+++ b/.github/actions/setup-java/action.yaml
@@ -21,14 +21,13 @@
 #################################################################################
 
 ---
-name: "Setup JDK 17"
-description: "Setup JDK 17"
+name: "Setup Java 19"
+description: "Setup Java 19"
 runs:
   using: "composite"
   steps:
-    - name: Setup JDK 17
-      uses: actions/setup-java@v3.13.0
+    - name: Setup Java
+      uses: actions/setup-java@v3
       with:
-        java-version: '17'
-        distribution: 'temurin'
-        cache: 'gradle'
+        java-version: '19'
+        distribution: 'adopt'

--- a/.github/actions/setup-java/action.yaml
+++ b/.github/actions/setup-java/action.yaml
@@ -1,0 +1,34 @@
+#################################################################################
+# Catena-X - Product Passport Consumer Application
+#
+# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+---
+name: "Setup JDK 17"
+description: "Setup JDK 17"
+runs:
+  using: "composite"
+  steps:
+    - name: Setup JDK 17
+      uses: actions/setup-java@v3.13.0
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: 'gradle'

--- a/.github/workflows/publish-swagger-hub.yaml
+++ b/.github/workflows/publish-swagger-hub.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Create and Download API specs
         shell: bash
         run: |
-          cd consumer-backend/productpass
+          cd backend/productpass
           echo "[INFO] - Compiling the backend"
           mvn -B clean install
           echo "[INFO] - Building a docker image - backend:test"
@@ -87,16 +87,16 @@ jobs:
       - name: Create API
         continue-on-error: true
         run: |
-          swaggerhub api:create ${{ env.SWAGGERHUB_USER }}/digital-product-pass/${{ env.DOWNSTREAM_VERSION }} -f ./consumer-backend/productpass/tractusx-dpp-api.yaml --visibility=public --published=unpublish
+          swaggerhub api:create ${{ env.SWAGGERHUB_USER }}/digital-product-pass/${{ env.DOWNSTREAM_VERSION }} -f ./backend/productpass/tractusx-dpp-api.yaml --visibility=public --published=unpublish
 
       # Post the API to SwaggerHub as "unpublished", because published APIs cannot be overwritten
       - name: Publish API Specs to SwaggerHub
         run: |
           if [[ ${{ env.DOWNSTREAM_VERSION }} != *-SNAPSHOT ]]; then
             echo "[INFO] - no snapshot, will set the API to 'published'";
-            swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/digital-product-pass/${{ env.DOWNSTREAM_VERSION }} -f ./consumer-backend/productpass/tractusx-dpp-api.yaml --visibility=public --published=publish
+            swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/digital-product-pass/${{ env.DOWNSTREAM_VERSION }} -f ./backend/productpass/tractusx-dpp-api.yaml --visibility=public --published=publish
             swaggerhub api:setdefault ${{ env.SWAGGERHUB_USER }}/digital-product-pass/${{ env.DOWNSTREAM_VERSION }}
           else
             echo "[INFO] - snapshot, will set the API to 'unpublished'";
-            swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/digital-product-pass/${{ env.DOWNSTREAM_VERSION }} -f ./consumer-backend/productpass/tractusx-dpp-api.yaml --visibility=public --published=unpublish
+            swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/digital-product-pass/${{ env.DOWNSTREAM_VERSION }} -f ./backend/productpass/tractusx-dpp-api.yaml --visibility=public --published=unpublish
           fi

--- a/.github/workflows/publish-swagger-hub.yaml
+++ b/.github/workflows/publish-swagger-hub.yaml
@@ -25,7 +25,9 @@ name: "Publish OpenAPI to Swaggerhub"
 
 on:
   push:
-    branches: [ "feature/swaggerhub-workflow" ]
+    branches: [ "main", "develop" ]
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_call:
     inputs:
       version:

--- a/.github/workflows/publish-swagger-hub.yaml
+++ b/.github/workflows/publish-swagger-hub.yaml
@@ -78,8 +78,9 @@ jobs:
           mvn -B clean install
           docker build . --tag dpp-backend:test
           docker run -p 8888:8888 --name test-container -d dpp-backend:test
-          sleep 5
-          curl -X GET http://localhost:8888/v3/api-docs.yaml > resources/openapi/yaml/tractusx-dpp-api.yaml
+          sleep 10
+          curl -X GET http://localhost:8888/v3/api-docs.yaml > ./tractusx-dpp-api.yaml
+          cat ./tractusx-dpp-api.yaml
           docker stop test-container
           docker rm test-container
               
@@ -87,16 +88,17 @@ jobs:
       - name: Create API
         continue-on-error: true
         run: |
-          swaggerhub api:create ${{ env.SWAGGERHUB_USER }}/digital-product-pass/${{ env.DOWNSTREAM_VERSION }} -f ./resources/openapi/yaml/tractusx-dpp-api.yaml --visibility=public --published=unpublish
+          ls -l
+          swaggerhub api:create ${{ env.SWAGGERHUB_USER }}/digital-product-pass/${{ env.DOWNSTREAM_VERSION }} -f ./consumer-backend/productpass/tractusx-dpp-api.yaml --visibility=public --published=unpublish
 
       # Post the API to SwaggerHub as "unpublished", because published APIs cannot be overwritten
       - name: Publish API Specs to SwaggerHub
         run: |
           if [[ ${{ env.DOWNSTREAM_VERSION }} != *-SNAPSHOT ]]; then
             echo "no snapshot, will set the API to 'published'";
-            swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/digital-product-pass/${{ env.DOWNSTREAM_VERSION }} -f ./resources/openapi/yaml/tractusx-dpp-api.yaml --visibility=public --published=publish
+            swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/digital-product-pass/${{ env.DOWNSTREAM_VERSION }} -f ./consumer-backend/productpass/tractusx-dpp-api.yaml --visibility=public --published=publish
             swaggerhub api:setdefault ${{ env.SWAGGERHUB_USER }}/digital-product-pass/${{ env.DOWNSTREAM_VERSION }}
           else
             echo "snapshot, will set the API to 'unpublished'";
-            swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/digital-product-pass/${{ env.DOWNSTREAM_VERSION }} -f ./resources/openapi/yaml/tractusx-dpp-api.yaml --visibility=public --published=unpublish
+            swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/digital-product-pass/${{ env.DOWNSTREAM_VERSION }} -f ./consumer-backend/productpass/tractusx-dpp-api.yaml --visibility=public --published=unpublish
           fi

--- a/.github/workflows/publish-swagger-hub.yaml
+++ b/.github/workflows/publish-swagger-hub.yaml
@@ -21,6 +21,8 @@
 name: "Publish OpenAPI to Swaggerhub"
 
 on:
+  push:
+    branches: [ "feature/swaggerhub-workflow" ]
   workflow_call:
     inputs:
       downstream-version:
@@ -34,7 +36,7 @@ on:
     inputs:
       downstream-version:
         required: false
-        description: "Version of the DPP API to be should be published"
+        description: "Version of the DPP API is to be published"
         type: string
       upstream-version:
         required: false
@@ -78,22 +80,22 @@ jobs:
 
       - name: Merge API specs
         run: |
-          ./gradlew -PapiTitle="Tractus-X EDC REST API" -PapiDescription="Tractus-X EDC API Documentation" :mergeApiSpec --input=./resources/openapi/yaml --output=./resources/openapi/yaml/tractusx-edc-api.yaml
+          ./gradlew -PapiTitle="Tractus-X DPP REST API" -PapiDescription="Tractus-X DPP API Documentation" :mergeApiSpec --input=./resources/openapi/yaml --output=./resources/openapi/yaml/tractusx-dpp-api.yaml
 
       # create API, will fail if exists
       - name: Create API
         continue-on-error: true
         run: |
-          swaggerhub api:create ${{ env.SWAGGERHUB_USER }}/tractusx-edc/${{ env.DOWNSTREAM_VERSION }} -f ./resources/openapi/yaml/tractusx-edc-api.yaml --visibility=public --published=unpublish
+          swaggerhub api:create ${{ env.SWAGGERHUB_USER }}/digital-product-pass/${{ env.DOWNSTREAM_VERSION }} -f ./resources/openapi/yaml/tractusx-dpp-api.yaml --visibility=public --published=unpublish
 
       # Post the API to SwaggerHub as "unpublished", because published APIs cannot be overwritten
       - name: Publish API Specs to SwaggerHub
         run: |
           if [[ ${{ env.DOWNSTREAM_VERSION }} != *-SNAPSHOT ]]; then
             echo "no snapshot, will set the API to 'published'";
-            swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/tractusx-edc/${{ env.DOWNSTREAM_VERSION }} -f ./resources/openapi/yaml/tractusx-edc-api.yaml --visibility=public --published=publish
-            swaggerhub api:setdefault ${{ env.SWAGGERHUB_USER }}/tractusx-edc/${{ env.DOWNSTREAM_VERSION }}
+            swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/digital-product-pass/${{ env.DOWNSTREAM_VERSION }} -f ./resources/openapi/yaml/tractusx-dpp-api.yaml --visibility=public --published=publish
+            swaggerhub api:setdefault ${{ env.SWAGGERHUB_USER }}/digital-product-pass/${{ env.DOWNSTREAM_VERSION }}
           else
             echo "snapshot, will set the API to 'unpublished'";
-            swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/tractusx-edc/${{ env.DOWNSTREAM_VERSION }} -f ./resources/openapi/yaml/tractusx-edc-api.yaml --visibility=public --published=unpublish
+            swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/digital-product-pass/${{ env.DOWNSTREAM_VERSION }} -f ./resources/openapi/yaml/tractusx-dpp-api.yaml --visibility=public --published=unpublish
           fi

--- a/.github/workflows/publish-swagger-hub.yaml
+++ b/.github/workflows/publish-swagger-hub.yaml
@@ -1,21 +1,24 @@
+#################################################################################
+# Catena-X - Product Passport Consumer Application
 #
-#  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
 #
-#  See the NOTICE file(s) distributed with this work for additional
-#  information regarding copyright ownership.
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
 #
-#  This program and the accompanying materials are made available under the
-#  terms of the Apache License, Version 2.0 which is available at
-#  https://www.apache.org/licenses/LICENSE-2.0
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
 #
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-#  License for the specific language governing permissions and limitations
-#  under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
 #
-#  SPDX-License-Identifier: Apache-2.0
-#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
 
 ---
 name: "Publish OpenAPI to Swaggerhub"

--- a/.github/workflows/publish-swagger-hub.yaml
+++ b/.github/workflows/publish-swagger-hub.yaml
@@ -1,0 +1,99 @@
+#
+#  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
+---
+name: "Publish OpenAPI to Swaggerhub"
+
+on:
+  workflow_call:
+    inputs:
+      downstream-version:
+        required: false
+        type: string
+      upstream-version:
+        required: false
+        type: string
+
+  workflow_dispatch:
+    inputs:
+      downstream-version:
+        required: false
+        description: "Version of the DPP API to be should be published"
+        type: string
+      upstream-version:
+        required: false
+        description: "Version of DPP which is to be used"
+        type: string
+
+jobs:
+  swagger-api:
+    runs-on: ubuntu-latest
+    env:
+      SWAGGERHUB_API_KEY: ${{ secrets.SWAGGERHUB_API_KEY }}
+      SWAGGERHUB_USER: ${{ secrets.SWAGGERHUB_USER }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-java
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+
+      - name: Install Swagger CLI
+        run: |
+          npm i -g swaggerhub-cli
+
+      - name: Extract versions
+        run: |
+          export DOWNSTREAM_VERSION=${{ inputs.downstream-version }}
+          export UPSTREAM_VERSION=${{ inputs.upstream-version }}
+          echo "DOWNSTREAM_VERSION=$DOWNSTREAM_VERSION" >> "$GITHUB_ENV"
+          echo "UPSTREAM_VERSION=$UPSTREAM_VERSION" >> "$GITHUB_ENV"
+
+      - name: Resolve TX DPP API Spec
+        shell: bash
+        run: |
+          ./gradlew resolve
+
+      - name: Download upstream API specs
+        run: |
+          curl -X GET https://api.swaggerhub.com/apis/eclipse-edc-bot/management-api/${{ env.UPSTREAM_VERSION }}/swagger.yaml > resources/openapi/yaml/upstream-management-api.yaml
+          curl -X GET https://api.swaggerhub.com/apis/eclipse-edc-bot/control-api/${{ env.UPSTREAM_VERSION }}/swagger.yaml > resources/openapi/yaml/upstream-control-api.yaml
+
+      - name: Merge API specs
+        run: |
+          ./gradlew -PapiTitle="Tractus-X EDC REST API" -PapiDescription="Tractus-X EDC API Documentation" :mergeApiSpec --input=./resources/openapi/yaml --output=./resources/openapi/yaml/tractusx-edc-api.yaml
+
+      # create API, will fail if exists
+      - name: Create API
+        continue-on-error: true
+        run: |
+          swaggerhub api:create ${{ env.SWAGGERHUB_USER }}/tractusx-edc/${{ env.DOWNSTREAM_VERSION }} -f ./resources/openapi/yaml/tractusx-edc-api.yaml --visibility=public --published=unpublish
+
+      # Post the API to SwaggerHub as "unpublished", because published APIs cannot be overwritten
+      - name: Publish API Specs to SwaggerHub
+        run: |
+          if [[ ${{ env.DOWNSTREAM_VERSION }} != *-SNAPSHOT ]]; then
+            echo "no snapshot, will set the API to 'published'";
+            swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/tractusx-edc/${{ env.DOWNSTREAM_VERSION }} -f ./resources/openapi/yaml/tractusx-edc-api.yaml --visibility=public --published=publish
+            swaggerhub api:setdefault ${{ env.SWAGGERHUB_USER }}/tractusx-edc/${{ env.DOWNSTREAM_VERSION }}
+          else
+            echo "snapshot, will set the API to 'unpublished'";
+            swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/tractusx-edc/${{ env.DOWNSTREAM_VERSION }} -f ./resources/openapi/yaml/tractusx-edc-api.yaml --visibility=public --published=unpublish
+          fi

--- a/.github/workflows/publish-swagger-hub.yaml
+++ b/.github/workflows/publish-swagger-hub.yaml
@@ -28,22 +28,17 @@ on:
     branches: [ "feature/swaggerhub-workflow" ]
   workflow_call:
     inputs:
-      downstream-version:
+      version:
         required: false
-        type: string
-      upstream-version:
-        required: false
+        default: 'main'
         type: string
 
   workflow_dispatch:
     inputs:
-      downstream-version:
+      version:
         required: false
         description: "Version of the DPP API is to be published"
-        type: string
-      upstream-version:
-        required: false
-        description: "Version of DPP which is to be used"
+        default: 'main'
         type: string
 
 jobs:
@@ -66,21 +61,23 @@ jobs:
 
       - name: Extract versions
         run: |
-          export DOWNSTREAM_VERSION=1.3.1
-          export UPSTREAM_VERSION=${{ inputs.upstream-version }}
-          echo "DOWNSTREAM_VERSION=$DOWNSTREAM_VERSION" >> "$GITHUB_ENV"
-          echo "UPSTREAM_VERSION=$UPSTREAM_VERSION" >> "$GITHUB_ENV"
+          export DOWNSTREAM_VERSION=${{ inputs.version }}
+          echo "[INFO] - DOWNSTREAM_VERSION=$DOWNSTREAM_VERSION" >> "$GITHUB_ENV"
 
       - name: Create and Download API specs
         shell: bash
         run: |
           cd consumer-backend/productpass
+          echo "[INFO] - Compiling the backend"
           mvn -B clean install
+          echo "[INFO] - Building a docker image - backend:test"
           docker build . --tag dpp-backend:test
+          echo "[INFO] - Starting a docker container to download API specs - test-container"
           docker run -p 8888:8888 --name test-container -d dpp-backend:test
-          sleep 10
+          echo "[INFO] - Wait for some seconds until the docker container comes up"
+          sleep 8
           curl -X GET http://localhost:8888/v3/api-docs.yaml > ./tractusx-dpp-api.yaml
-          cat ./tractusx-dpp-api.yaml
+          echo "[INFO] - Stopping and removing docker container"
           docker stop test-container
           docker rm test-container
               
@@ -88,17 +85,16 @@ jobs:
       - name: Create API
         continue-on-error: true
         run: |
-          ls -l
           swaggerhub api:create ${{ env.SWAGGERHUB_USER }}/digital-product-pass/${{ env.DOWNSTREAM_VERSION }} -f ./consumer-backend/productpass/tractusx-dpp-api.yaml --visibility=public --published=unpublish
 
       # Post the API to SwaggerHub as "unpublished", because published APIs cannot be overwritten
       - name: Publish API Specs to SwaggerHub
         run: |
           if [[ ${{ env.DOWNSTREAM_VERSION }} != *-SNAPSHOT ]]; then
-            echo "no snapshot, will set the API to 'published'";
+            echo "[INFO] - no snapshot, will set the API to 'published'";
             swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/digital-product-pass/${{ env.DOWNSTREAM_VERSION }} -f ./consumer-backend/productpass/tractusx-dpp-api.yaml --visibility=public --published=publish
             swaggerhub api:setdefault ${{ env.SWAGGERHUB_USER }}/digital-product-pass/${{ env.DOWNSTREAM_VERSION }}
           else
-            echo "snapshot, will set the API to 'unpublished'";
+            echo "[INFO] - snapshot, will set the API to 'unpublished'";
             swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/digital-product-pass/${{ env.DOWNSTREAM_VERSION }} -f ./consumer-backend/productpass/tractusx-dpp-api.yaml --visibility=public --published=unpublish
           fi

--- a/.github/workflows/publish-swagger-hub.yaml
+++ b/.github/workflows/publish-swagger-hub.yaml
@@ -66,25 +66,23 @@ jobs:
 
       - name: Extract versions
         run: |
-          export DOWNSTREAM_VERSION=${{ inputs.downstream-version }}
+          export DOWNSTREAM_VERSION=1.3.1
           export UPSTREAM_VERSION=${{ inputs.upstream-version }}
           echo "DOWNSTREAM_VERSION=$DOWNSTREAM_VERSION" >> "$GITHUB_ENV"
           echo "UPSTREAM_VERSION=$UPSTREAM_VERSION" >> "$GITHUB_ENV"
 
-      - name: Resolve TX DPP API Spec
+      - name: Create and Download API specs
         shell: bash
         run: |
-          ./gradlew resolve
-
-      - name: Download upstream API specs
-        run: |
-          curl -X GET https://api.swaggerhub.com/apis/eclipse-edc-bot/management-api/${{ env.UPSTREAM_VERSION }}/swagger.yaml > resources/openapi/yaml/upstream-management-api.yaml
-          curl -X GET https://api.swaggerhub.com/apis/eclipse-edc-bot/control-api/${{ env.UPSTREAM_VERSION }}/swagger.yaml > resources/openapi/yaml/upstream-control-api.yaml
-
-      - name: Merge API specs
-        run: |
-          ./gradlew -PapiTitle="Tractus-X DPP REST API" -PapiDescription="Tractus-X DPP API Documentation" :mergeApiSpec --input=./resources/openapi/yaml --output=./resources/openapi/yaml/tractusx-dpp-api.yaml
-
+          cd consumer-backend/productpass
+          mvn -B clean install
+          docker build . --tag dpp-backend:test
+          docker run -p 8888:8888 --name test-container -d dpp-backend:test
+          sleep 5
+          curl -X GET http://localhost:8888/v3/api-docs.yaml > resources/openapi/yaml/tractusx-dpp-api.yaml
+          docker stop test-container
+          docker rm test-container
+              
       # create API, will fail if exists
       - name: Create API
         continue-on-error: true


### PR DESCRIPTION
# Why we create this PR?
 
A workflow is prepared in order to host backend API specs to the central swaggerhub
Link: https://app.swaggerhub.com/apis/eclipse-tractusx-bot/digital-product-pass/1.3.1

# What we want to achieve with this PR?
 
To include the API specs to the EcoPass Kit for a reference implementation https://eclipse-tractusx.github.io/docs-kits/kits/Eco_Pass_KIT/page-software-development-view/#api-specification
 
# What is new?
 
## Added
- Added SwaggerHub workflow to host backend API Specs for a reference implementation

# Linked Issue(s):

https://github.com/eclipse-tractusx/eco-pass-kit/issues/20