### PR TITLE
[ 2º ] - Hotfix/trg-7-02: license and copyright header

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Frontend
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -18,7 +19,7 @@
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-##################################################################################
+#################################################################################
 
 [*]
 charset = utf-8

--- a/.env
+++ b/.env
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Frontend
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -18,7 +19,7 @@
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-##################################################################################
+#################################################################################
 
 VITE_APP_NAME=Product Passport Application
 VITE_BASE_URL=http://localhost:8080

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X -  Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,26 @@
+<!-- 
+  Catena-X - Digital Product Passport Application 
+ 
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
+  See the NOTICE file(s) distributed with this work for additional
+  information regarding copyright ownership.
+ 
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0.
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+  either express or implied. See the
+  License for the specific language govern in permissions and limitations
+  under the License.
+ 
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 # Why we create this PR?
  
 << Quick description why the PR is being opened >>

--- a/.github/actions/setup-java/action.yaml
+++ b/.github/actions/setup-java/action.yaml
@@ -1,8 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
 # Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
-# Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,16 +1,25 @@
-# Copyright 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+#################################################################################
+# Catena-X - Digital Product Passport Application
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
 
 # This workflow uses actions that are not certified by GitHub.
 # They are provided by a third-party and are governed by

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/.github/workflows/helm-upgrade.yaml
+++ b/.github/workflows/helm-upgrade.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/.github/workflows/publish-dpp-backend-docker-image.yml
+++ b/.github/workflows/publish-dpp-backend-docker-image.yml
@@ -1,8 +1,8 @@
 #################################################################################
-# Catena-X - Digital Product Pass Application
+# Catena-X - Digital Product Passport Application
 #
 # Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
-# Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/.github/workflows/publish-dpp-frontend-docker-image.yml
+++ b/.github/workflows/publish-dpp-frontend-docker-image.yml
@@ -1,8 +1,8 @@
 #################################################################################
-# Catena-X - Digital Product Pass Application
+# Catena-X - Digital Product Passport Application
 #
 # Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
-# Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/.github/workflows/publish-swagger-hub.yaml
+++ b/.github/workflows/publish-swagger-hub.yaml
@@ -2,7 +2,7 @@
 # Catena-X - Digital Product Passport Application
 #
 # Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
-# Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/.github/workflows/release-helm-charts.yml
+++ b/.github/workflows/release-helm-charts.yml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/.github/workflows/sonar-scan.yaml
+++ b/.github/workflows/sonar-scan.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,8 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
-# Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/.github/workflows/veracode-pipeline.yml
+++ b/.github/workflows/veracode-pipeline.yml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/.github/workflows/veracode-upload.yml
+++ b/.github/workflows/veracode-upload.yml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Frontend
+# Catena-X - Digital Product Passport Application
 #
 # Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -18,7 +19,7 @@
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-##################################################################################
+#################################################################################
 
 __pycache__/
 .DS_Store

--- a/.nginx/nginx.conf
+++ b/.nginx/nginx.conf
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Frontend
+# Catena-X -  Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -18,7 +19,7 @@
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-##################################################################################
+#################################################################################
 
 server {
     listen 8080;

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Frontend
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -18,7 +19,7 @@
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-##################################################################################
+#################################################################################
 
 repos:
   - repo: https://github.com/gitguardian/ggshield

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,5 +1,5 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Frontend
+# Catena-X - Digital Product Passport Application
 #
 # Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
@@ -19,7 +19,7 @@
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-##################################################################################
+#################################################################################
 
 # List of false positives
 CVE-2023-5363

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,8 +1,9 @@
-<!--
-  Catena-X - Product Passport Consumer Application
+<!-- 
+  Catena-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-<!--
-  Catena-X - Product Passport Consumer Frontend
+<!-- 
+  Catena-X - Digital Product Passport Application 
  
   Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,8 +1,9 @@
-<!--
-  Catena-X - Product Passport Consumer Frontend
+<!-- 
+  Catena-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,9 @@
-<!--
-  Catena-X - Product Passport Consumer Frontend
+<!-- 
+  Catena-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #################################################################################
-# Catena-X - Digital Product Pass Frontend Application
+# Catena-X - Digital Product Passport Application
 #
 # Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,8 +1,9 @@
-<!--
-  Catena-X - Product Passport Consumer Frontend
+<!-- 
+  Catena-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,8 +1,9 @@
-<!--
-  Catena-X - Product Passport Consumer Frontend
+<!-- 
+  Catena-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-<!--
-  Catena-X - Product Passport Consumer Frontend
+<!-- 
+  Catena-X - Digital Product Passport Application 
  
   Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,9 @@
-<!--
-  Catena-X - Product Passport Consumer Frontend
+<!-- 
+  Catena-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/buildAndDeploy.sh
+++ b/buildAndDeploy.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 #################################################################################
-# Catena-X - Product Passport Consumer Frontend
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/digital-product-pass/.helmignore
+++ b/charts/digital-product-pass/.helmignore
@@ -1,3 +1,26 @@
+#################################################################################
+# Catena-X - Digital Product Passport Application
+#
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
 # Patterns to ignore when building packages.
 # This supports shell glob matching, relative path matching, and
 # negation (prefixed with !). Only one pattern per line.

--- a/charts/digital-product-pass/Chart.yaml
+++ b/charts/digital-product-pass/Chart.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/digital-product-pass/README.md
+++ b/charts/digital-product-pass/README.md
@@ -1,3 +1,26 @@
+<!-- 
+  Catena-X - Digital Product Passport Application 
+ 
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
+  See the NOTICE file(s) distributed with this work for additional
+  information regarding copyright ownership.
+ 
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0.
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+  either express or implied. See the
+  License for the specific language govern in permissions and limitations
+  under the License.
+ 
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 # digital-product-pass
 
 ![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)

--- a/charts/digital-product-pass/templates/_helpers.tpl
+++ b/charts/digital-product-pass/templates/_helpers.tpl
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -18,7 +19,7 @@
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-#################################################################################e governing permissions and
+################################################################################# governing permissions and
 
 {{/*
 Expand the name of the chart.

--- a/charts/digital-product-pass/templates/configmap-backend.yaml
+++ b/charts/digital-product-pass/templates/configmap-backend.yaml
@@ -1,5 +1,5 @@
 #################################################################################
-# Catena-X - Digital Product Pass Application
+# Catena-X - Digital Product Passport Application
 #
 # Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation

--- a/charts/digital-product-pass/templates/deployment-backend.yaml
+++ b/charts/digital-product-pass/templates/deployment-backend.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/digital-product-pass/templates/deployment-frontend.yaml
+++ b/charts/digital-product-pass/templates/deployment-frontend.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/digital-product-pass/templates/ingress-backend.yaml
+++ b/charts/digital-product-pass/templates/ingress-backend.yaml
@@ -1,24 +1,25 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
-#
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
-#
-# See the NOTICE file(s) distributed with this work for additional
-# information regarding copyright ownership.
-#
-# This program and the accompanying materials are made available under the
-# terms of the Apache License, Version 2.0 which is available at
-# https://www.apache.org/licenses/LICENSE-2.0.
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-# either express or implied. See the
-# License for the specific language govern in permissions and limitations
-# under the License.
-#
-# SPDX-License-Identifier: Apache-2.0
-#################################################################################
+# Catena-X - Digital Product Passport Application
+  #
+  # Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+  #
+  # See the NOTICE file(s) distributed with this work for additional
+  # information regarding copyright ownership.
+  #
+  # This program and the accompanying materials are made available under the
+  # terms of the Apache License, Version 2.0 which is available at
+  # https://www.apache.org/licenses/LICENSE-2.0.
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+  # either express or implied. See the
+  # License for the specific language govern in permissions and limitations
+  # under the License.
+  #
+  # SPDX-License-Identifier: Apache-2.0
+  #################################################################################
 
 {{- if .Values.backend.ingress.enabled -}}
 {{- $fullName := .Values.backend.name -}}

--- a/charts/digital-product-pass/templates/ingress-frontend.yaml
+++ b/charts/digital-product-pass/templates/ingress-frontend.yaml
@@ -1,24 +1,25 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
-#
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
-#
-# See the NOTICE file(s) distributed with this work for additional
-# information regarding copyright ownership.
-#
-# This program and the accompanying materials are made available under the
-# terms of the Apache License, Version 2.0 which is available at
-# https://www.apache.org/licenses/LICENSE-2.0.
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-# either express or implied. See the
-# License for the specific language govern in permissions and limitations
-# under the License.
-#
-# SPDX-License-Identifier: Apache-2.0
-#################################################################################
+# Catena-X - Digital Product Passport Application
+  #
+  # Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+  #
+  # See the NOTICE file(s) distributed with this work for additional
+  # information regarding copyright ownership.
+  #
+  # This program and the accompanying materials are made available under the
+  # terms of the Apache License, Version 2.0 which is available at
+  # https://www.apache.org/licenses/LICENSE-2.0.
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+  # either express or implied. See the
+  # License for the specific language govern in permissions and limitations
+  # under the License.
+  #
+  # SPDX-License-Identifier: Apache-2.0
+  #################################################################################
 
 {{- if .Values.frontend.ingress.enabled -}}
 {{- $fullName := .Values.frontend.name -}}

--- a/charts/digital-product-pass/templates/pvc-data.yaml
+++ b/charts/digital-product-pass/templates/pvc-data.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/digital-product-pass/templates/secret-backend.yaml
+++ b/charts/digital-product-pass/templates/secret-backend.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/digital-product-pass/templates/service-backend.yaml
+++ b/charts/digital-product-pass/templates/service-backend.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/digital-product-pass/templates/service-frontend.yaml
+++ b/charts/digital-product-pass/templates/service-frontend.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/digital-product-pass/templates/tests/test-dpp-connection.yaml
+++ b/charts/digital-product-pass/templates/tests/test-dpp-connection.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -39,4 +40,3 @@ spec:
       command: ['/bin/sh','-c']
       args: ["i=0; wget '{{ .Values.backend.name }}:{{ .Values.backend.service.port }}'/health -O /dev/null; while [ $i -ne 5 ]; do wget '{{ .Values.backend.name }}:{{ .Values.backend.service.port }}'/health -O /dev/null; sleep 6; i=$(($i+1)); done"]
   restartPolicy: Never
-  

--- a/charts/digital-product-pass/values-beta.yaml
+++ b/charts/digital-product-pass/values-beta.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/digital-product-pass/values-dev.yaml
+++ b/charts/digital-product-pass/values-dev.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/digital-product-pass/values-int.yaml
+++ b/charts/digital-product-pass/values-int.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/digital-product-pass/values.yaml
+++ b/charts/digital-product-pass/values.yaml
@@ -1,5 +1,5 @@
 #################################################################################
-# Catena-X - Digital Product Pass Application
+# Catena-X - Digital Product Passport Application
 #
 # Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X -  Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/cypress/e2e/sign-in/e2e.cy.js
+++ b/cypress/e2e/sign-in/e2e.cy.js
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,9 +1,9 @@
-<!--
-  Catena-X - Digital Product Pass Application
+<!-- 
+  Catena-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
-  Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
- 
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/deployment/infrastructure/edc-consumer/Chart.yaml
+++ b/deployment/infrastructure/edc-consumer/Chart.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/deployment/infrastructure/edc-consumer/README.md
+++ b/deployment/infrastructure/edc-consumer/README.md
@@ -1,3 +1,26 @@
+<!-- 
+  Catena-X - Digital Product Passport Application 
+ 
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
+  See the NOTICE file(s) distributed with this work for additional
+  information regarding copyright ownership.
+ 
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0.
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+  either express or implied. See the
+  License for the specific language govern in permissions and limitations
+  under the License.
+ 
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 # tractusx-connector
 
 ![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.0](https://img.shields.io/badge/AppVersion-0.5.0-informational?style=flat-square)

--- a/deployment/infrastructure/edc-consumer/values-beta.yaml
+++ b/deployment/infrastructure/edc-consumer/values-beta.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/deployment/infrastructure/edc-consumer/values-int.yaml
+++ b/deployment/infrastructure/edc-consumer/values-int.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/deployment/infrastructure/edc-consumer/values.yaml
+++ b/deployment/infrastructure/edc-consumer/values.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/deployment/infrastructure/edc-provider/Chart.yaml
+++ b/deployment/infrastructure/edc-provider/Chart.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/deployment/infrastructure/edc-provider/README.md
+++ b/deployment/infrastructure/edc-provider/README.md
@@ -1,3 +1,26 @@
+<!-- 
+  Catena-X - Digital Product Passport Application 
+ 
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
+  See the NOTICE file(s) distributed with this work for additional
+  information regarding copyright ownership.
+ 
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0.
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+  either express or implied. See the
+  License for the specific language govern in permissions and limitations
+  under the License.
+ 
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 # tractusx-connector
 
 ![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.0](https://img.shields.io/badge/AppVersion-0.5.0-informational?style=flat-square)

--- a/deployment/infrastructure/edc-provider/data-service/.helmignore
+++ b/deployment/infrastructure/edc-provider/data-service/.helmignore
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Frontend
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -18,7 +19,7 @@
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-##################################################################################
+#################################################################################
 
 # Patterns to ignore when building packages.
 # This supports shell glob matching, relative path matching, and

--- a/deployment/infrastructure/edc-provider/data-service/Chart.yaml
+++ b/deployment/infrastructure/edc-provider/data-service/Chart.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Frontend
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -18,7 +19,7 @@
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-##################################################################################
+#################################################################################
 ---
 apiVersion: v2
 name: data-service

--- a/deployment/infrastructure/edc-provider/data-service/README.md
+++ b/deployment/infrastructure/edc-provider/data-service/README.md
@@ -1,3 +1,26 @@
+<!-- 
+  Catena-X - Digital Product Passport Application 
+ 
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
+  See the NOTICE file(s) distributed with this work for additional
+  information regarding copyright ownership.
+ 
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0.
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+  either express or implied. See the
+  License for the specific language govern in permissions and limitations
+  under the License.
+ 
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 # data-service
 
 ![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)

--- a/deployment/infrastructure/edc-provider/data-service/templates/_helpers.tpl
+++ b/deployment/infrastructure/edc-provider/data-service/templates/_helpers.tpl
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Frontend
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -18,7 +19,8 @@
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-##################################################################################
+#################################################################################
+
 {{/*
 Expand the name of the chart.
 */}}

--- a/deployment/infrastructure/edc-provider/data-service/templates/deployment.yaml
+++ b/deployment/infrastructure/edc-provider/data-service/templates/deployment.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Frontend
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -18,7 +19,7 @@
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-##################################################################################
+#################################################################################
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/deployment/infrastructure/edc-provider/data-service/templates/ingress.yaml
+++ b/deployment/infrastructure/edc-provider/data-service/templates/ingress.yaml
@@ -1,24 +1,25 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Frontend
-#
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
-#
-# See the NOTICE file(s) distributed with this work for additional
-# information regarding copyright ownership.
-#
-# This program and the accompanying materials are made available under the
-# terms of the Apache License, Version 2.0 which is available at
-# https://www.apache.org/licenses/LICENSE-2.0.
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-# either express or implied. See the
-# License for the specific language govern in permissions and limitations
-# under the License.
-#
-# SPDX-License-Identifier: Apache-2.0
-##################################################################################
+# Catena-X - Digital Product Passport Application
+  #
+  # Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+  #
+  # See the NOTICE file(s) distributed with this work for additional
+  # information regarding copyright ownership.
+  #
+  # This program and the accompanying materials are made available under the
+  # terms of the Apache License, Version 2.0 which is available at
+  # https://www.apache.org/licenses/LICENSE-2.0.
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+  # either express or implied. See the
+  # License for the specific language govern in permissions and limitations
+  # under the License.
+  #
+  # SPDX-License-Identifier: Apache-2.0
+  #################################################################################
 
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "data-service.fullname" . -}}

--- a/deployment/infrastructure/edc-provider/data-service/templates/service.yaml
+++ b/deployment/infrastructure/edc-provider/data-service/templates/service.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Frontend
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -18,7 +19,7 @@
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-##################################################################################
+#################################################################################
 
 ---
 apiVersion: v1

--- a/deployment/infrastructure/edc-provider/data-service/values-beta.yaml
+++ b/deployment/infrastructure/edc-provider/data-service/values-beta.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Frontend
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -18,7 +19,7 @@
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-##################################################################################
+#################################################################################
 
 ---
 # Default values for backend.

--- a/deployment/infrastructure/edc-provider/data-service/values-dev.yaml
+++ b/deployment/infrastructure/edc-provider/data-service/values-dev.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Frontend
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -18,7 +19,7 @@
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-##################################################################################
+#################################################################################
 
 ---
 # Default values for backend.

--- a/deployment/infrastructure/edc-provider/data-service/values-int.yaml
+++ b/deployment/infrastructure/edc-provider/data-service/values-int.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Frontend
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -18,7 +19,7 @@
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-##################################################################################
+#################################################################################
 
 ---
 # Default values for backend.

--- a/deployment/infrastructure/edc-provider/data-service/values.yaml
+++ b/deployment/infrastructure/edc-provider/data-service/values.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Frontend
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -18,7 +19,7 @@
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-##################################################################################
+#################################################################################
 
 ---
 # Default values for backend.

--- a/deployment/infrastructure/edc-provider/values-beta.yaml
+++ b/deployment/infrastructure/edc-provider/values-beta.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/deployment/infrastructure/edc-provider/values-int.yaml
+++ b/deployment/infrastructure/edc-provider/values-int.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/deployment/infrastructure/edc-provider/values.yaml
+++ b/deployment/infrastructure/edc-provider/values.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/deployment/infrastructure/registry/Chart.yaml
+++ b/deployment/infrastructure/registry/Chart.yaml
@@ -1,6 +1,8 @@
-###############################################################
-# Copyright (c) 2021, 2023 Robert Bosch Manufacturing Solutions GmbH
-# Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#################################################################################
+# Catena-X - Digital Product Passport Application
+#
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -10,13 +12,14 @@
 # https://www.apache.org/licenses/LICENSE-2.0.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-###############################################################
+#################################################################################
 
 apiVersion: v2
 name: registry

--- a/deployment/infrastructure/registry/README.md
+++ b/deployment/infrastructure/registry/README.md
@@ -1,3 +1,26 @@
+<!-- 
+  Catena-X - Digital Product Passport Application 
+ 
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
+  See the NOTICE file(s) distributed with this work for additional
+  information regarding copyright ownership.
+ 
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0.
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+  either express or implied. See the
+  License for the specific language govern in permissions and limitations
+  under the License.
+ 
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 # registry
 
 ![Version: 0.3.23](https://img.shields.io/badge/Version-0.3.23-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)

--- a/deployment/infrastructure/registry/values.yaml
+++ b/deployment/infrastructure/registry/values.yaml
@@ -1,6 +1,8 @@
-###############################################################
-# Copyright (c) 2021, 2023 Robert Bosch Manufacturing Solutions GmbH
-# Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#################################################################################
+# Catena-X - Digital Product Passport Application
+#
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -10,13 +12,14 @@
 # https://www.apache.org/licenses/LICENSE-2.0.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-###############################################################
+#################################################################################
 
 
 provider-dtr:

--- a/deployment/local/docker/Keycloak/README.md
+++ b/deployment/local/docker/Keycloak/README.md
@@ -1,8 +1,9 @@
-<!--
-  Catena-X - Product Passport Consumer Application
+<!-- 
+  Catena-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/deployment/local/docker/README.md
+++ b/deployment/local/docker/README.md
@@ -1,8 +1,9 @@
-<!--
-  Catena-X - Product Passport Consumer Application
+<!-- 
+  Catena-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/deployment/local/postman/README.md
+++ b/deployment/local/postman/README.md
@@ -1,8 +1,9 @@
-<!--
-  Catena-X - Product Passport Consumer Frontend
+<!-- 
+  Catena-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/deployment/local/scripts/init-values.sh
+++ b/deployment/local/scripts/init-values.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #################################################################################
-# Catena-X - Digital Product Pass Application
+# Catena-X - Digital Product Passport Application
 #
 # Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
@@ -20,7 +20,7 @@
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-##################################################################################
+#################################################################################
 
 
 set -o errexit

--- a/deployment/local/storage/pv-data.yaml
+++ b/deployment/local/storage/pv-data.yaml
@@ -1,8 +1,8 @@
 #################################################################################
 # Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
-# Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -20,7 +20,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #################################################################################
-
 apiVersion: v1
 kind: PersistentVolume
 metadata:

--- a/deployment/local/storage/pvc-data.yaml
+++ b/deployment/local/storage/pvc-data.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/deployment/local/testing/README.md
+++ b/deployment/local/testing/README.md
@@ -1,8 +1,9 @@
-<!--
-  Catena-X - Product Passport Consumer Application
+<!-- 
+  Catena-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/deployment/local/testing/delete-testdata.sh
+++ b/deployment/local/testing/delete-testdata.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/deployment/local/testing/functions.sh
+++ b/deployment/local/testing/functions.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/deployment/local/testing/transform-and-upload.sh
+++ b/deployment/local/testing/transform-and-upload.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/deployment/local/testing/upload-testdata.sh
+++ b/deployment/local/testing/upload-testdata.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -1,9 +1,9 @@
-<!--
-  Catena-X - Product Passport Consumer Frontend
+<!-- 
+  Catena-X - Digital Product Passport Application 
  
-   Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
-   Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
- 
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/docs/IaC.md
+++ b/docs/IaC.md
@@ -1,8 +1,9 @@
-<!--
-  Catena-X - Product Passport Consumer Application
+<!-- 
+  Catena-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,9 @@
-<!--
-  Catena-X - Product Passport Consumer Application
+<!-- 
+  Catena-X - Digital Product Passport Application 
  
-   Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
-   Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
- 
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,8 +1,9 @@
-<!--
-  Catena-X - Product Passport Consumer Frontend
+<!-- 
+  Catena-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/docs/RELEASE_USER.md
+++ b/docs/RELEASE_USER.md
@@ -1,5 +1,5 @@
-<!--
-  Catena-X - Digital Product Passport Application
+<!-- 
+  Catena-X - Digital Product Passport Application 
  
   Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation

--- a/docs/SECRETS_MANAGEMENT.md
+++ b/docs/SECRETS_MANAGEMENT.md
@@ -1,8 +1,9 @@
-<!--
-  Catena-X - Product Passport Consumer Application
+<!-- 
+  Catena-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/docs/admin guide/Admin_Guide.md
+++ b/docs/admin guide/Admin_Guide.md
@@ -1,9 +1,9 @@
-<!--
-  Catena-X - Product Passport Consumer Application
+<!-- 
+  Catena-X - Digital Product Passport Application 
  
   Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
-  Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
- 
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/docs/arc42/Arc42.md
+++ b/docs/arc42/Arc42.md
@@ -1,9 +1,9 @@
-<!--
-  Catena-X - Product Passport Consumer Frontend
+<!-- 
+  Catena-X - Digital Product Passport Application 
  
   Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
- 
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/docs/business statement/Business Statement.md
+++ b/docs/business statement/Business Statement.md
@@ -1,9 +1,9 @@
-<!--
-  Catena-X - Digital Product Pass Application
+<!-- 
+  Catena-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
-  Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
- 
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/docs/cypress/CYPRESS.md
+++ b/docs/cypress/CYPRESS.md
@@ -1,22 +1,23 @@
-<!--
-  Catena-X - Product Passport Consumer Application
-
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+<!-- 
+  Catena-X - Digital Product Passport Application 
+ 
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
-
+ 
   This program and the accompanying materials are made available under the
   terms of the Apache License, Version 2.0 which is available at
   https://www.apache.org/licenses/LICENSE-2.0.
-
+ 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
   either express or implied. See the
   License for the specific language govern in permissions and limitations
   under the License.
-
+ 
   SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/docs/data retrieval guide/DataRetrievalGuide.md
+++ b/docs/data retrieval guide/DataRetrievalGuide.md
@@ -1,8 +1,9 @@
-<!--
-  Catena-X - Product Passport Consumer Frontend
+<!-- 
+  Catena-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/docs/notice.md
+++ b/docs/notice.md
@@ -1,9 +1,9 @@
-<!--
-  Catena-X - Digital Product Pass Application
+<!-- 
+  Catena-X - Digital Product Passport Application 
  
   Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
-  Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
- 
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/docs/user manual/User Manual Product Viewer App.md
+++ b/docs/user manual/User Manual Product Viewer App.md
@@ -1,9 +1,9 @@
-<!--
-  Catena-X - Digital Product Pass Application
+<!-- 
+  Catena-X - Digital Product Passport Application 
  
   Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
-  Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
- 
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  
@@ -20,7 +20,6 @@
  
   SPDX-License-Identifier: Apache-2.0
 -->
-
 # User Manual
 
 This manual provides a step by step introduction on how to use the Product Pass Viewer app and gives an overview on its functionalities.

--- a/dpp-backend/charts/digital-product-pass-backend/.helmignore
+++ b/dpp-backend/charts/digital-product-pass-backend/.helmignore
@@ -1,3 +1,26 @@
+#################################################################################
+# Catena-X - Digital Product Passport Application
+#
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
 # Patterns to ignore when building packages.
 # This supports shell glob matching, relative path matching, and
 # negation (prefixed with !). Only one pattern per line.

--- a/dpp-backend/charts/digital-product-pass-backend/Chart.yaml
+++ b/dpp-backend/charts/digital-product-pass-backend/Chart.yaml
@@ -1,5 +1,5 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
 # Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation

--- a/dpp-backend/charts/digital-product-pass-backend/README.md
+++ b/dpp-backend/charts/digital-product-pass-backend/README.md
@@ -1,3 +1,26 @@
+<!-- 
+  Catena-X - Digital Product Passport Application 
+ 
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
+  See the NOTICE file(s) distributed with this work for additional
+  information regarding copyright ownership.
+ 
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0.
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+  either express or implied. See the
+  License for the specific language govern in permissions and limitations
+  under the License.
+ 
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 # digital-product-pass-backend
 
 ![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)

--- a/dpp-backend/charts/digital-product-pass-backend/templates/NOTES.txt
+++ b/dpp-backend/charts/digital-product-pass-backend/templates/NOTES.txt
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/dpp-backend/charts/digital-product-pass-backend/templates/_helpers.tpl
+++ b/dpp-backend/charts/digital-product-pass-backend/templates/_helpers.tpl
@@ -1,24 +1,25 @@
-#################################################################################
-# Catena-X - Product Passport Consumer Application
-#
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
-#
-# See the NOTICE file(s) distributed with this work for additional
-# information regarding copyright ownership.
-#
-# This program and the accompanying materials are made available under the
-# terms of the Apache License, Version 2.0 which is available at
-# https://www.apache.org/licenses/LICENSE-2.0.
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-# either express or implied. See the
-# License for the specific language govern in permissions and limitations
-# under the License.
-#
-# SPDX-License-Identifier: Apache-2.0
-#################################################################################e governing permissions and
+#####################################################################################
+    # Catena-X - Digital Product Passport Application
+    #
+    # Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+    # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+    #
+    # See the NOTICE file(s) distributed with this work for additional
+    # information regarding copyright ownership.
+    #
+    # This program and the accompanying materials are made available under the
+    # terms of the Apache License, Version 2.0 which is available at
+    # https://www.apache.org/licenses/LICENSE-2.0.
+    #
+    # Unless required by applicable law or agreed to in writing, software
+    # distributed under the License is distributed on an "AS IS" BASIS
+    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+    # either express or implied. See the
+    # License for the specific language govern in permissions and limitations
+    # under the License.
+    #
+    # SPDX-License-Identifier: Apache-2.0
+    ################################################################################# governing permissions and
 
 {{/*
 Expand the name of the chart.

--- a/dpp-backend/charts/digital-product-pass-backend/templates/configmap.yaml
+++ b/dpp-backend/charts/digital-product-pass-backend/templates/configmap.yaml
@@ -1,5 +1,5 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
 # Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation

--- a/dpp-backend/charts/digital-product-pass-backend/templates/deployment.yaml
+++ b/dpp-backend/charts/digital-product-pass-backend/templates/deployment.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/dpp-backend/charts/digital-product-pass-backend/templates/ingress.yaml
+++ b/dpp-backend/charts/digital-product-pass-backend/templates/ingress.yaml
@@ -1,24 +1,25 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
-#
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
-#
-# See the NOTICE file(s) distributed with this work for additional
-# information regarding copyright ownership.
-#
-# This program and the accompanying materials are made available under the
-# terms of the Apache License, Version 2.0 which is available at
-# https://www.apache.org/licenses/LICENSE-2.0.
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-# either express or implied. See the
-# License for the specific language govern in permissions and limitations
-# under the License.
-#
-# SPDX-License-Identifier: Apache-2.0
-#################################################################################
+# Catena-X - Digital Product Passport Application
+  #
+  # Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+  #
+  # See the NOTICE file(s) distributed with this work for additional
+  # information regarding copyright ownership.
+  #
+  # This program and the accompanying materials are made available under the
+  # terms of the Apache License, Version 2.0 which is available at
+  # https://www.apache.org/licenses/LICENSE-2.0.
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+  # either express or implied. See the
+  # License for the specific language govern in permissions and limitations
+  # under the License.
+  #
+  # SPDX-License-Identifier: Apache-2.0
+  #################################################################################
 
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := .Values.name -}}

--- a/dpp-backend/charts/digital-product-pass-backend/templates/pvc-data.yaml
+++ b/dpp-backend/charts/digital-product-pass-backend/templates/pvc-data.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/dpp-backend/charts/digital-product-pass-backend/templates/secret.yaml
+++ b/dpp-backend/charts/digital-product-pass-backend/templates/secret.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/dpp-backend/charts/digital-product-pass-backend/templates/service.yaml
+++ b/dpp-backend/charts/digital-product-pass-backend/templates/service.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/dpp-backend/charts/digital-product-pass-backend/templates/serviceaccount.yaml
+++ b/dpp-backend/charts/digital-product-pass-backend/templates/serviceaccount.yaml
@@ -1,3 +1,26 @@
+#################################################################################
+# Catena-X - Digital Product Passport Application
+#
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount

--- a/dpp-backend/charts/digital-product-pass-backend/templates/tests/test-connection.yaml
+++ b/dpp-backend/charts/digital-product-pass-backend/templates/tests/test-connection.yaml
@@ -1,7 +1,8 @@
- #################################################################################
-# Catena-X - Product Passport Consumer Application
+#################################################################################
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/dpp-backend/charts/digital-product-pass-backend/values-dev.yaml
+++ b/dpp-backend/charts/digital-product-pass-backend/values-dev.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/dpp-backend/charts/digital-product-pass-backend/values-int.yaml
+++ b/dpp-backend/charts/digital-product-pass-backend/values-int.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/dpp-backend/charts/digital-product-pass-backend/values.yaml
+++ b/dpp-backend/charts/digital-product-pass-backend/values.yaml
@@ -1,5 +1,5 @@
 #################################################################################
-# Catena-X - Digital Product Pass Application
+# Catena-X - Digital Product Passport Application
 #
 # Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation

--- a/dpp-backend/digitalproductpass/.gitattributes
+++ b/dpp-backend/digitalproductpass/.gitattributes
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Backend
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/.gitignore
+++ b/dpp-backend/digitalproductpass/.gitignore
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Backend
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/Dockerfile
+++ b/dpp-backend/digitalproductpass/Dockerfile
@@ -1,5 +1,5 @@
 #################################################################################
-# Catena-X - Digital Product Pass Backend Application
+# Catena-X - Digital Product Passport Application
 #
 # Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation

--- a/dpp-backend/digitalproductpass/README.md
+++ b/dpp-backend/digitalproductpass/README.md
@@ -1,5 +1,5 @@
-<!--
-  Catena-X - Product Passport Consumer Backend
+<!-- 
+  Catena-X - Digital Product Passport Application 
  
   Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation

--- a/dpp-backend/digitalproductpass/deploy.sh
+++ b/dpp-backend/digitalproductpass/deploy.sh
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Frontend
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -18,7 +19,7 @@
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-##################################################################################
+#################################################################################
 
 echo "[INFO] Starting build..."
 echo "[INFO] Checking for docker daemon and opened containers..."

--- a/dpp-backend/digitalproductpass/docs/tests/UNIT_TESTS.md
+++ b/dpp-backend/digitalproductpass/docs/tests/UNIT_TESTS.md
@@ -1,7 +1,8 @@
-<!--
-  Catena-X - Product Passport Consumer Backend
+<!-- 
+  Catena-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/mvnw
+++ b/dpp-backend/digitalproductpass/mvnw
@@ -1,8 +1,9 @@
 #!/bin/sh
 #################################################################################
-# Catena-X - Product Passport Consumer Backend
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/mvnw.cmd
+++ b/dpp-backend/digitalproductpass/mvnw.cmd
@@ -4,15 +4,15 @@ rem Copyright (c) 2022, 2023 Contributors to the CatenaX (ng) GitHub Organisatio
 rem Licensed under the Apache License, Version 2.0 (the "License");
 rem you may not use this file except in compliance with the License.
 rem You may obtain a copy of the License at
-rem 
+rem
 rem     http://www.apache.org/licenses/LICENSE-2.0
-rem 
+rem
 rem Unless required by applicable law or agreed to in writing, software
 rem distributed under the License is distributed on an "AS IS" BASIS,
 rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 rem See the License for the specific language governing permissions and
 rem limitations under the License.
-rem 
+rem
 rem SPDX-License-Identifier: Apache-2.0
 
 @REM ----------------------------------------------------------------------------

--- a/dpp-backend/digitalproductpass/pom.xml
+++ b/dpp-backend/digitalproductpass/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~
-  ~ Catena-X - Digital Product Pass Backend
+  ~ Catena-X - Digital Product Pass Application
   ~
   ~ Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
   ~ Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/Application.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/Application.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/AppConfig.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/AppConfig.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/DiscoveryConfig.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/DiscoveryConfig.java
@@ -1,9 +1,9 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- * Copyright (c) 2022, 2023 Contributors to the CatenaX (ng) GitHub Organisation.
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/DtrConfig.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/DtrConfig.java
@@ -1,6 +1,6 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Pass Backend
+ * Catena-X - Digital Product Passport Application
  *
  * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/IrsConfig.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/IrsConfig.java
@@ -1,9 +1,9 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- * Copyright (c) 2022, 2023 Contributors to the CatenaX (ng) GitHub Organisation.
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/PassportConfig.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/PassportConfig.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/ProcessConfig.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/ProcessConfig.java
@@ -1,9 +1,9 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- * Copyright (c) 2022, 2023 Contributors to the CatenaX (ng) GitHub Organisation.
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/SecurityConfig.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/SecurityConfig.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/ThreadConfig.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/ThreadConfig.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/VaultConfig.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/VaultConfig.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/WebConfig.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/WebConfig.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/exceptions/ConfigException.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/exceptions/ConfigException.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/exceptions/ControllerException.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/exceptions/ControllerException.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/exceptions/DataModelException.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/exceptions/DataModelException.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/exceptions/ManagerException.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/exceptions/ManagerException.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/exceptions/ServiceException.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/exceptions/ServiceException.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/exceptions/ServiceInitializationException.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/exceptions/ServiceInitializationException.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/http/controllers/AppController.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/http/controllers/AppController.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/http/controllers/api/ApiController.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/http/controllers/api/ApiController.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/http/controllers/api/ContractController.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/http/controllers/api/ContractController.java
@@ -1,6 +1,6 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Pass Backend
+ * Catena-X - Digital Product Passport Application
  *
  * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/http/controllers/api/IrsController.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/http/controllers/api/IrsController.java
@@ -1,6 +1,6 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Pass Backend
+ * Catena-X - Digital Product Passport Application
  *
  * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/http/controllers/auth/AuthController.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/http/controllers/auth/AuthController.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/http/controllers/error/ErrorResponseController.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/http/controllers/error/ErrorResponseController.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/http/middleware/BaseInterceptor.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/http/middleware/BaseInterceptor.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/http/middleware/InterceptorConfig.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/http/middleware/InterceptorConfig.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/interfaces/ServiceInitializationInterface.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/interfaces/ServiceInitializationInterface.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/listeners/AppListener.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/listeners/AppListener.java
@@ -1,6 +1,6 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Pass Backend
+ * Catena-X - Digital Product Passport Application
  *
  * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/managers/DtrSearchManager.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/managers/DtrSearchManager.java
@@ -1,6 +1,6 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Pass Backend
+ * Catena-X - Digital Product Passport Application
  *
  * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/managers/ProcessDataModel.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/managers/ProcessDataModel.java
@@ -1,9 +1,9 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- * Copyright (c) 2022, 2023 Contributors to the CatenaX (ng) GitHub Organisation.
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/managers/ProcessManager.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/managers/ProcessManager.java
@@ -1,6 +1,6 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Pass Backend
+ * Catena-X - Digital Product Passport Application
  *
  * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/managers/TreeManager.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/managers/TreeManager.java
@@ -1,9 +1,9 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- * Copyright (c) 2022, 2023 Contributors to the CatenaX (ng) GitHub Organisation.
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/auth/Credential.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/auth/Credential.java
@@ -1,3 +1,27 @@
+/*********************************************************************************
+ *
+ * Catena-X - Digital Product Passport Application
+ *
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
 
 /*********************************************************************************
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/auth/JwtToken.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/auth/JwtToken.java
@@ -1,3 +1,27 @@
+/*********************************************************************************
+ *
+ * Catena-X - Digital Product Passport Application
+ *
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
 
 /*********************************************************************************
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/auth/UserCredential.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/auth/UserCredential.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/auth/UserInfo.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/auth/UserInfo.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/catenax/BpnDiscovery.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/catenax/BpnDiscovery.java
@@ -1,6 +1,6 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
  * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/catenax/Discovery.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/catenax/Discovery.java
@@ -1,6 +1,6 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
  * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/catenax/Dtr.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/catenax/Dtr.java
@@ -1,6 +1,6 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Pass Backend
+ * Catena-X - Digital Product Passport Application
  *
  * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/catenax/EdcDiscoveryEndpoint.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/catenax/EdcDiscoveryEndpoint.java
@@ -1,6 +1,6 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
  * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/dtregistry/DigitalTwin.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/dtregistry/DigitalTwin.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/dtregistry/EndPoint.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/dtregistry/EndPoint.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/dtregistry/SubModel.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/dtregistry/SubModel.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/edc/AssetSearch.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/edc/AssetSearch.java
@@ -1,9 +1,9 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- * Copyright (c) 2022, 2023 Contributors to the CatenaX (ng) GitHub Organisation.
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/edc/DataPlaneEndpoint.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/edc/DataPlaneEndpoint.java
@@ -1,9 +1,9 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- * Copyright (c) 2022, 2023 Contributors to the CatenaX (ng) GitHub Organisation.
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/edc/Jwt.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/edc/Jwt.java
@@ -1,9 +1,9 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- * Copyright (c) 2022, 2023 Contributors to the CatenaX (ng) GitHub Organisation.
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/http/Response.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/http/Response.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/http/requests/DiscoverySearch.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/http/requests/DiscoverySearch.java
@@ -1,9 +1,9 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- * Copyright (c) 2022, 2023 Contributors to the CatenaX (ng) GitHub Organisation.
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/http/requests/Search.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/http/requests/Search.java
@@ -1,9 +1,9 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- * Copyright (c) 2022, 2023 Contributors to the CatenaX (ng) GitHub Organisation.
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/http/requests/TokenRequest.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/http/requests/TokenRequest.java
@@ -1,6 +1,6 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Pass Backend
+ * Catena-X - Digital Product Passport Application
  *
  * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/http/responses/IdResponse.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/http/responses/IdResponse.java
@@ -1,9 +1,9 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- * Copyright (c) 2022, 2023 Contributors to the CatenaX (ng) GitHub Organisation.
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/irs/Job.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/irs/Job.java
@@ -1,9 +1,9 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- * Copyright (c) 2022, 2023 Contributors to the CatenaX (ng) GitHub Organisation.
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/irs/JobHistory.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/irs/JobHistory.java
@@ -1,9 +1,9 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- * Copyright (c) 2022, 2023 Contributors to the CatenaX (ng) GitHub Organisation.
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/irs/JobRequest.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/irs/JobRequest.java
@@ -1,9 +1,9 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- * Copyright (c) 2022, 2023 Contributors to the CatenaX (ng) GitHub Organisation.
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/irs/JobResponse.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/irs/JobResponse.java
@@ -1,9 +1,9 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- * Copyright (c) 2022, 2023 Contributors to the CatenaX (ng) GitHub Organisation.
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/irs/Relationship.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/irs/Relationship.java
@@ -1,9 +1,9 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- * Copyright (c) 2022, 2023 Contributors to the CatenaX (ng) GitHub Organisation.
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/manager/History.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/manager/History.java
@@ -1,9 +1,9 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- * Copyright (c) 2022, 2023 Contributors to the CatenaX (ng) GitHub Organisation.
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/manager/Node.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/manager/Node.java
@@ -1,9 +1,9 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- * Copyright (c) 2022, 2023 Contributors to the CatenaX (ng) GitHub Organisation.
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/manager/NodeComponent.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/manager/NodeComponent.java
@@ -1,9 +1,9 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- * Copyright (c) 2022, 2023 Contributors to the CatenaX (ng) GitHub Organisation.
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/manager/Process.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/manager/Process.java
@@ -1,9 +1,9 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- * Copyright (c) 2022, 2023 Contributors to the CatenaX (ng) GitHub Organisation.
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/manager/SearchStatus.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/manager/SearchStatus.java
@@ -1,9 +1,9 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- * Copyright (c) 2022, 2023 Contributors to the CatenaX (ng) GitHub Organisation.
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/manager/Status.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/manager/Status.java
@@ -1,9 +1,9 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- * Copyright (c) 2022, 2023 Contributors to the CatenaX (ng) GitHub Organisation.
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Catalog.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Catalog.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/CatalogRequest.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/CatalogRequest.java
@@ -1,9 +1,9 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- * Copyright (c) 2022, 2023 Contributors to the CatenaX (ng) GitHub Organisation.
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Constraint.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Constraint.java
@@ -1,9 +1,9 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- * Copyright (c) 2022, 2023 Contributors to the CatenaX (ng) GitHub Organisation.
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/DataService.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/DataService.java
@@ -1,9 +1,9 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- * Copyright (c) 2022, 2023 Contributors to the CatenaX (ng) GitHub Organisation.
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Dataset.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Dataset.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/DidDocument.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/DidDocument.java
@@ -1,9 +1,9 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- * Copyright (c) 2022, 2023 Contributors to the CatenaX (ng) GitHub Organisation.
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Distribution.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Distribution.java
@@ -1,9 +1,9 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- * Copyright (c) 2022, 2023 Contributors to the CatenaX (ng) GitHub Organisation.
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/EdcResponse.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/EdcResponse.java
@@ -1,9 +1,9 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- * Copyright (c) 2022, 2023 Contributors to the CatenaX (ng) GitHub Organisation.
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Negotiation.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Negotiation.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/NegotiationRequest.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/NegotiationRequest.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Offer.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Offer.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Properties.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Properties.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Set.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Set.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Transfer.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Transfer.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/TransferRequest.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/TransferRequest.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/passports/PassportResponse.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/passports/PassportResponse.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/service/BaseService.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/service/BaseService.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/AasService.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/AasService.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/AuthenticationService.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/AuthenticationService.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/CatenaXService.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/CatenaXService.java
@@ -1,6 +1,6 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Pass Backend
+ * Catena-X - Digital Product Passport Application
  *
  * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/DataPlaneService.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/DataPlaneService.java
@@ -1,6 +1,6 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Pass Backend
+ * Catena-X - Digital Product Passport Application
  *
  * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/DataTransferService.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/DataTransferService.java
@@ -1,6 +1,6 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Pass Backend
+ * Catena-X - Digital Product Passport Application
  *
  * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/IrsService.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/IrsService.java
@@ -1,6 +1,6 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Pass Backend
+ * Catena-X - Digital Product Passport Application
  *
  * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/VaultService.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/VaultService.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/utils/CatenaXUtil.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/CatenaXUtil.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/utils/CrypUtil.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/CrypUtil.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/utils/CsvUtil.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/CsvUtil.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/utils/DateTimeUtil.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/DateTimeUtil.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/utils/EdcUtil.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/EdcUtil.java
@@ -1,6 +1,6 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Pass Backend
+ * Catena-X - Digital Product Passport Application
  *
  * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation

--- a/dpp-backend/digitalproductpass/src/main/java/utils/FileUtil.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/FileUtil.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/utils/HttpUtil.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/HttpUtil.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/utils/JsonUtil.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/JsonUtil.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/utils/LogUtil.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/LogUtil.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/utils/NumericUtil.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/NumericUtil.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/utils/PassportUtil.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/PassportUtil.java
@@ -1,9 +1,9 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- * Copyright (c) 2022, 2023 Contributors to the CatenaX (ng) GitHub Organisation.
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/src/main/java/utils/ReflectionUtil.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/ReflectionUtil.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/utils/StringUtil.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/StringUtil.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/utils/SystemUtil.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/SystemUtil.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/utils/ThreadUtil.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/ThreadUtil.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/utils/YamlUtil.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/YamlUtil.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/utils/exceptions/UtilException.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/exceptions/UtilException.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/resources/application.yml
+++ b/dpp-backend/digitalproductpass/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 #################################################################################
-# Catena-X - Digital Product Pass Backend
+# Catena-X - Digital Product Passport Application
 #
 # Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation

--- a/dpp-backend/digitalproductpass/src/main/resources/logback-spring.xml
+++ b/dpp-backend/digitalproductpass/src/main/resources/logback-spring.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~
-  ~ Catena-X - Product Passport Consumer Backend
+  ~ Catena-X - Digital Product Pass Application
   ~
-  ~ Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
-  ~
+  ~ Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  ~ Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   ~ See the NOTICE file(s) distributed with this work for additional
   ~ information regarding copyright ownership.
   ~

--- a/dpp-backend/digitalproductpass/src/test/java/managers/DtrSearchManagerTest.java
+++ b/dpp-backend/digitalproductpass/src/test/java/managers/DtrSearchManagerTest.java
@@ -1,3 +1,28 @@
+/*********************************************************************************
+ *
+ * Catena-X - Digital Product Pass Application
+ *
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package managers;
 
 import org.eclipse.tractusx.digitalproductpass.config.DtrConfig;

--- a/dpp-backend/digitalproductpass/src/test/java/managers/ProcessDataModelTest.java
+++ b/dpp-backend/digitalproductpass/src/test/java/managers/ProcessDataModelTest.java
@@ -1,3 +1,28 @@
+/*********************************************************************************
+ *
+ * Catena-X - Digital Product Pass Application
+ *
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package managers;
 
 import org.eclipse.tractusx.digitalproductpass.exceptions.DataModelException;

--- a/dpp-backend/digitalproductpass/src/test/java/managers/ProcessManagerTest.java
+++ b/dpp-backend/digitalproductpass/src/test/java/managers/ProcessManagerTest.java
@@ -1,3 +1,28 @@
+/*********************************************************************************
+ *
+ * Catena-X - Digital Product Pass Application
+ *
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package managers;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/dpp-backend/digitalproductpass/src/test/java/managers/TreeManagerTest.java
+++ b/dpp-backend/digitalproductpass/src/test/java/managers/TreeManagerTest.java
@@ -1,3 +1,28 @@
+/*********************************************************************************
+ *
+ * Catena-X - Digital Product Pass Application
+ *
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package managers;
 
 import jakarta.servlet.http.HttpServletRequest;

--- a/dpp-backend/digitalproductpass/src/test/java/mocks/MockedHttpSession.java
+++ b/dpp-backend/digitalproductpass/src/test/java/mocks/MockedHttpSession.java
@@ -1,3 +1,28 @@
+/*********************************************************************************
+ *
+ * Catena-X - Digital Product Pass Application
+ *
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package mocks;
 
 import jakarta.servlet.ServletContext;

--- a/dpp-backend/digitalproductpass/src/test/java/services/AasServiceTest.java
+++ b/dpp-backend/digitalproductpass/src/test/java/services/AasServiceTest.java
@@ -1,3 +1,28 @@
+/*********************************************************************************
+ *
+ * Catena-X - Digital Product Pass Application
+ *
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package services;
 
 import jakarta.servlet.http.HttpServletRequest;

--- a/dpp-backend/digitalproductpass/src/test/java/services/AuthenticationServiceTest.java
+++ b/dpp-backend/digitalproductpass/src/test/java/services/AuthenticationServiceTest.java
@@ -1,3 +1,28 @@
+/*********************************************************************************
+ *
+ * Catena-X - Digital Product Pass Application
+ *
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package services;
 
 import jakarta.servlet.http.HttpServletRequest;

--- a/dpp-backend/digitalproductpass/src/test/java/services/CatenaXServiceTest.java
+++ b/dpp-backend/digitalproductpass/src/test/java/services/CatenaXServiceTest.java
@@ -1,3 +1,28 @@
+/*********************************************************************************
+ *
+ * Catena-X - Digital Product Pass Application
+ *
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package services;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/dpp-backend/digitalproductpass/src/test/java/services/DataPlaneServiceTest.java
+++ b/dpp-backend/digitalproductpass/src/test/java/services/DataPlaneServiceTest.java
@@ -1,3 +1,28 @@
+/*********************************************************************************
+ *
+ * Catena-X - Digital Product Pass Application
+ *
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package services;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/dpp-backend/digitalproductpass/src/test/java/services/DataTransferServiceTest.java
+++ b/dpp-backend/digitalproductpass/src/test/java/services/DataTransferServiceTest.java
@@ -1,3 +1,28 @@
+/*********************************************************************************
+ *
+ * Catena-X - Digital Product Pass Application
+ *
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package services;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/dpp-backend/digitalproductpass/src/test/java/services/IrsServiceTest.java
+++ b/dpp-backend/digitalproductpass/src/test/java/services/IrsServiceTest.java
@@ -1,3 +1,28 @@
+/*********************************************************************************
+ *
+ * Catena-X - Digital Product Pass Application
+ *
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package services;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/dpp-backend/digitalproductpass/src/test/java/utils/CrypUtilTest.java
+++ b/dpp-backend/digitalproductpass/src/test/java/utils/CrypUtilTest.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Pass Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/test/java/utils/JsonUtilTest.java
+++ b/dpp-backend/digitalproductpass/src/test/java/utils/JsonUtilTest.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Pass Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/test/java/utils/LogUtilTest.java
+++ b/dpp-backend/digitalproductpass/src/test/java/utils/LogUtilTest.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Pass Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/test/java/utils/SystemUtilTest.java
+++ b/dpp-backend/digitalproductpass/src/test/java/utils/SystemUtilTest.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Pass Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/test/java/utils/YamlUtilTest.java
+++ b/dpp-backend/digitalproductpass/src/test/java/utils/YamlUtilTest.java
@@ -1,8 +1,10 @@
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Catena-X - Digital Product Pass Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/test/resources/application-test.yml
+++ b/dpp-backend/digitalproductpass/src/test/resources/application-test.yml
@@ -1,5 +1,5 @@
 #################################################################################
-# Catena-X - Digital Product Pass Backend
+# Catena-X - Digital Product Passport Application
 #
 # Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation

--- a/dpp-backend/scripts/README.md
+++ b/dpp-backend/scripts/README.md
@@ -1,9 +1,9 @@
-<!--
-  Catena-X - Digital Product Passport Application
+<!-- 
+  Catena-X - Digital Product Passport Application 
  
   Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
- 
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/dpp-backend/scripts/get-data.sh
+++ b/dpp-backend/scripts/get-data.sh
@@ -1,5 +1,5 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Application
+# Catena-X - Digital Product Passport Application
 #
 # Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation

--- a/dpp-backend/scripts/logging.ini
+++ b/dpp-backend/scripts/logging.ini
@@ -1,5 +1,5 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-; Catena-X - DigitalProduct Passport Application
+; Catena-X - Digital Product Passport Application
 ;
 ; Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
 ; Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation

--- a/dpp-backend/scripts/utilities/authentication.py
+++ b/dpp-backend/scripts/utilities/authentication.py
@@ -1,5 +1,5 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Catena-X -  Digital Product Passport Application
 #
 # Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation

--- a/dpp-backend/scripts/utilities/operators.py
+++ b/dpp-backend/scripts/utilities/operators.py
@@ -20,6 +20,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #################################################################################
+
 # Set log levels
 from shutil import copyfile, move
 import shutil

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Frontend
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/index.html
+++ b/index.html
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/pre-commit-config.yaml
+++ b/pre-commit-config.yaml
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Frontend
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -18,7 +19,7 @@
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-##################################################################################
+#################################################################################
 
 repos:
   - repo: https://github.com/gitguardian/ggshield

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,8 @@
 #################################################################################
-# Catena-X - Product Passport Consumer Frontend
+# Catena-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -18,7 +19,7 @@
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-##################################################################################
+#################################################################################
 
 sonar.projectKey=catenax-ng_product-battery-passport-consumer-app
 sonar.organization=catenax-ng

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/assets/plugins/vuetify.js
+++ b/src/assets/plugins/vuetify.js
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/assets/plugins/webfontloader.js
+++ b/src/assets/plugins/webfontloader.js
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/assets/styles/components/general/contractModal.scss
+++ b/src/assets/styles/components/general/contractModal.scss
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/assets/styles/components/general/dialog.scss
+++ b/src/assets/styles/components/general/dialog.scss
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/assets/styles/components/general/footer.scss
+++ b/src/assets/styles/components/general/footer.scss
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/assets/styles/components/general/header.scss
+++ b/src/assets/styles/components/general/header.scss
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -19,6 +20,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
 @media (max-width: 585px) {
   .header-container {
     padding: 0px 14px 0 0px !important;

--- a/src/assets/styles/components/general/loading.scss
+++ b/src/assets/styles/components/general/loading.scss
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/assets/styles/components/general/notFound.scss
+++ b/src/assets/styles/components/general/notFound.scss
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -19,6 +20,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
 .page-not-found {
   height: 100vh !important;
   word-break: break-word;

--- a/src/assets/styles/components/general/recursiveTree.scss
+++ b/src/assets/styles/components/general/recursiveTree.scss
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/assets/styles/components/general/search.scss
+++ b/src/assets/styles/components/general/search.scss
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/assets/styles/components/general/tooltip.scss
+++ b/src/assets/styles/components/general/tooltip.scss
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/assets/styles/components/landing/searchView.scss
+++ b/src/assets/styles/components/landing/searchView.scss
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/assets/styles/components/passport/additionalData.scss
+++ b/src/assets/styles/components/passport/additionalData.scss
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/assets/styles/components/passport/cards.scss
+++ b/src/assets/styles/components/passport/cards.scss
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/assets/styles/components/passport/documentField.scss
+++ b/src/assets/styles/components/passport/documentField.scss
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -19,6 +20,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
 .box {
   background: #eaf1fe!important;
   flex-direction: row!important;

--- a/src/assets/styles/components/passport/elementChart.scss
+++ b/src/assets/styles/components/passport/elementChart.scss
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/assets/styles/components/passport/field.scss
+++ b/src/assets/styles/components/passport/field.scss
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -19,6 +20,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
 .info-dialog {
   cursor: pointer;
   .icon {

--- a/src/assets/styles/components/passport/passportPage.scss
+++ b/src/assets/styles/components/passport/passportPage.scss
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -19,7 +20,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
 .header-title {
   font-size: 16px;
   font-weight: 500;

--- a/src/assets/styles/components/passport/sections.scss
+++ b/src/assets/styles/components/passport/sections.scss
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -19,6 +20,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
 .section {
   display: flex;
   .full-width {

--- a/src/assets/styles/config/variables.scss
+++ b/src/assets/styles/config/variables.scss
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/assets/styles/style.css
+++ b/src/assets/styles/style.css
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/general/Alert.vue
+++ b/src/components/general/Alert.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/general/Dialog.vue
+++ b/src/components/general/Dialog.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/general/ErrorComponent.vue
+++ b/src/components/general/ErrorComponent.vue
@@ -1,9 +1,9 @@
-
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/general/FieldBox.vue
+++ b/src/components/general/FieldBox.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  
@@ -42,4 +43,3 @@ export default {
 }
 </script>
 
-        

--- a/src/components/general/Footer.vue
+++ b/src/components/general/Footer.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/general/Header.vue
+++ b/src/components/general/Header.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  
@@ -19,6 +20,7 @@
  
   SPDX-License-Identifier: Apache-2.0
 -->
+
 <template>
   <div class="header-container">
     <v-container fluid class="header">

--- a/src/components/general/LoadingComponent.vue
+++ b/src/components/general/LoadingComponent.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/general/NotAuthorizedComponent.vue
+++ b/src/components/general/NotAuthorizedComponent.vue
@@ -1,25 +1,25 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
- 
+
   This program and the accompanying materials are made available under the
   terms of the Apache License, Version 2.0 which is available at
   https://www.apache.org/licenses/LICENSE-2.0.
- 
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
   either express or implied. See the
   License for the specific language govern in permissions and limitations
   under the License.
- 
+
   SPDX-License-Identifier: Apache-2.0
 -->
-
 
 <template>
   <v-container

--- a/src/components/general/NotAvailableComponent.vue
+++ b/src/components/general/NotAvailableComponent.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/general/QrcodeStrem.vue
+++ b/src/components/general/QrcodeStrem.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/general/RecursiveAdditionalData.vue
+++ b/src/components/general/RecursiveAdditionalData.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/general/RecursiveComponent.vue
+++ b/src/components/general/RecursiveComponent.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/general/RecursiveTree.vue
+++ b/src/components/general/RecursiveTree.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/general/SearchInput.vue
+++ b/src/components/general/SearchInput.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/general/SectionHeader.vue
+++ b/src/components/general/SectionHeader.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/general/Spinner.vue
+++ b/src/components/general/Spinner.vue
@@ -1,22 +1,23 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
- 
+
   This program and the accompanying materials are made available under the
   terms of the Apache License, Version 2.0 which is available at
   https://www.apache.org/licenses/LICENSE-2.0.
- 
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
   either express or implied. See the
   License for the specific language govern in permissions and limitations
   under the License.
- 
+
   SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/src/components/general/StepperItem.vue
+++ b/src/components/general/StepperItem.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/general/TabsComponent.vue
+++ b/src/components/general/TabsComponent.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/general/Tooltip.vue
+++ b/src/components/general/Tooltip.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/passport/AttributeField.vue
+++ b/src/components/passport/AttributeField.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/passport/BarChart.vue
+++ b/src/components/passport/BarChart.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/passport/BatteryCards.vue
+++ b/src/components/passport/BatteryCards.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/passport/DocumentField.vue
+++ b/src/components/passport/DocumentField.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/passport/ElementChart.vue
+++ b/src/components/passport/ElementChart.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/passport/Field.vue
+++ b/src/components/passport/Field.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/passport/GeneralCards.vue
+++ b/src/components/passport/GeneralCards.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/passport/InstructionsField.vue
+++ b/src/components/passport/InstructionsField.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/passport/PassportHeader.vue
+++ b/src/components/passport/PassportHeader.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/passport/Section.vue
+++ b/src/components/passport/Section.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/passport/TransmissionCards.vue
+++ b/src/components/passport/TransmissionCards.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/passport/sections/AdditionalData.vue
+++ b/src/components/passport/sections/AdditionalData.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/passport/sections/BatteryComposition.vue
+++ b/src/components/passport/sections/BatteryComposition.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/passport/sections/CellChemistry.vue
+++ b/src/components/passport/sections/CellChemistry.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/passport/sections/Characteristics.vue
+++ b/src/components/passport/sections/Characteristics.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/passport/sections/Commercial.vue
+++ b/src/components/passport/sections/Commercial.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/passport/sections/Components.vue
+++ b/src/components/passport/sections/Components.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/passport/sections/Documents.vue
+++ b/src/components/passport/sections/Documents.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/passport/sections/ElectrochemicalProperties.vue
+++ b/src/components/passport/sections/ElectrochemicalProperties.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/passport/sections/Exchange.vue
+++ b/src/components/passport/sections/Exchange.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/passport/sections/GeneralInformation.vue
+++ b/src/components/passport/sections/GeneralInformation.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/passport/sections/Handling.vue
+++ b/src/components/passport/sections/Handling.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/passport/sections/Identification.vue
+++ b/src/components/passport/sections/Identification.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/passport/sections/Instructions.vue
+++ b/src/components/passport/sections/Instructions.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/passport/sections/Metadata.vue
+++ b/src/components/passport/sections/Metadata.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/passport/sections/Operation.vue
+++ b/src/components/passport/sections/Operation.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/passport/sections/ProductSpecificParameters.vue
+++ b/src/components/passport/sections/ProductSpecificParameters.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/passport/sections/Serialization.vue
+++ b/src/components/passport/sections/Serialization.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/passport/sections/Sources.vue
+++ b/src/components/passport/sections/Sources.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/passport/sections/SparePartSupplier.vue
+++ b/src/components/passport/sections/SparePartSupplier.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/passport/sections/StateOfBattery.vue
+++ b/src/components/passport/sections/StateOfBattery.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/passport/sections/StateOfHealth.vue
+++ b/src/components/passport/sections/StateOfHealth.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/passport/sections/Sustainability.vue
+++ b/src/components/passport/sections/Sustainability.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/components/passport/sections/Typology.vue
+++ b/src/components/passport/sections/Typology.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -19,7 +20,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import { createApp } from 'vue';
 import App from './App.vue';
 import store from './store';

--- a/src/router.js
+++ b/src/router.js
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/services/Authentication.js
+++ b/src/services/Authentication.js
@@ -1,5 +1,5 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
  * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation

--- a/src/services/BackendService.js
+++ b/src/services/BackendService.js
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -19,6 +20,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import { BACKEND_URL, API_MAX_RETRIES, API_DELAY, AUTO_SIGN } from "@/services/service.const";
 import axios from "axios";
 import jsonUtil from "@/utils/jsonUtil.js";

--- a/src/services/service.const.js
+++ b/src/services/service.const.js
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/utils/authUtil.js
+++ b/src/utils/authUtil.js
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/utils/configUtil.js
+++ b/src/utils/configUtil.js
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/utils/cryptUtil.js
+++ b/src/utils/cryptUtil.js
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/utils/jsonUtil.js
+++ b/src/utils/jsonUtil.js
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/utils/numberUtil.js
+++ b/src/utils/numberUtil.js
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/utils/passportUtil.js
+++ b/src/utils/passportUtil.js
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -19,6 +20,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import iconMappings from "@/config/templates/iconMappings.json";
 
 export default {

--- a/src/utils/threadUtil.js
+++ b/src/utils/threadUtil.js
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/views/PageNotFound.vue
+++ b/src/views/PageNotFound.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/views/PassportView.vue
+++ b/src/views/PassportView.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Digital Product Passport Frontend
- 
+  Catena-X - Digital Product Passport Application
+
   Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -1,8 +1,9 @@
 <!--
-  Catena-X - Product Passport Consumer Frontend
- 
-  Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
- 
+  Catena-X - Digital Product Passport Application
+
+  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+
   See the NOTICE file(s) distributed with this work for additional
   information regarding copyright ownership.
  

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,8 @@
 /**
- * Catena-X - Product Passport Consumer Frontend
+ * Catena-X -  Digital Product Passport Application
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.


### PR DESCRIPTION
# Why we create this PR?
 
To be compliant with [TRG-7.02](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02)

# What we want to achieve with this PR?
 
To update and include the latest license and copyright header in all the files needed.


# What is new?
 
## Updated
- Updated the license headers in all the files to the latest "license and copyright header" of 2024

## Linked to:

Closes #187 