### PR TITLE
fix(qr-code): re-added missing import

### DIFF
--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -104,9 +104,7 @@
 </template>
 
 <script>
-import { QrcodeStream } from "vue3-qrcode-reader";
-import CatenaLogo from "../media/logo.png";
-import QRFrame from "../media/qrFrame.svg";
+import QrcodeStream from "../components/general/QrcodeStrem.vue";
 import BatteryScanning from "../media/battery-img.jpeg";
 // New picture
 // import BatteryScanning from "../media/backgroundart.jpg";


### PR DESCRIPTION
# Why we create this PR?
 
The QR code import in the search view was wrong, so no qr code search was performed
 
# What we want to achieve with this PR?
 
Recreate release candidate v2.1.1 to include the qr component import
 
# What is new?
 
## Issues fixed
- Added missing QR code import in searchView component

Solving this issue:

https://github.com/eclipse-tractusx/digital-product-pass/blob/5f5009595e0e1ffd0aab75fef771250b7882809d/src/views/SearchView.vue#L107 

Closes: https://github.com/eclipse-tractusx/digital-product-pass/issues/224
