### PR TITLE
Hotfix/Header Licenses: Renamed catena-x to tractus-x and removed basf from licenses

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 /**
- * Catena-X -  Digital Product Passport Application
+ * Tractus-X -  Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!-- 
-  Catena-X - Digital Product Passport Application 
+  Tractus-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/.github/actions/setup-java/action.yaml
+++ b/.github/actions/setup-java/action.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/.github/workflows/helm-upgrade.yaml
+++ b/.github/workflows/helm-upgrade.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/.github/workflows/publish-dpp-backend-docker-image.yml
+++ b/.github/workflows/publish-dpp-backend-docker-image.yml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/.github/workflows/publish-dpp-frontend-docker-image.yml
+++ b/.github/workflows/publish-dpp-frontend-docker-image.yml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/.github/workflows/publish-swagger-hub.yaml
+++ b/.github/workflows/publish-swagger-hub.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/.github/workflows/release-helm-charts.yml
+++ b/.github/workflows/release-helm-charts.yml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/.github/workflows/sonar-scan.yaml
+++ b/.github/workflows/sonar-scan.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/.github/workflows/veracode-pipeline.yml
+++ b/.github/workflows/veracode-pipeline.yml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/.github/workflows/veracode-upload.yml
+++ b/.github/workflows/veracode-upload.yml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/.nginx/nginx.conf
+++ b/.nginx/nginx.conf
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X -  Digital Product Passport Application
+# Tractus-X -  Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,7 +1,7 @@
 <!-- 
-  Catena-X - Digital Product Passport Application 
+  Tractus-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [released]
+## [v2.1.3] - 19-02-2024
+
+## Updated
+- Renamed "Catena-X" to "Tractus-X" in header license prefix
+- Removed BASF from the header license and license.
 
 ## [released]
 ## [v2.1.2] - 16-02-2024

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- 
-  Catena-X - Digital Product Passport Application 
+  Tractus-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 <!-- 
-  Catena-X - Digital Product Passport Application 
+  Tractus-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA      
+   Copyright 2022, 2023 BMW AG, Henkel AG & Co. KGaA      
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022, 2023 BMW AG, Henkel AG & Co. KGaA      
+   Copyright 2022, 2024 BMW AG, Henkel AG & Co. KGaA      
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,7 +1,7 @@
 <!-- 
-  Catena-X - Digital Product Passport Application 
+  Tractus-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ In particular, the appliction is used to access the battery passport data provid
 
 ### Software Version
 #### Helm Chart Version
-<pre id="helm-version"><a href="https://github.com/eclipse-tractusx/digital-product-pass/releases/tag/digital-product-pass-2.1.2">2.1.2</a></pre>
+<pre id="helm-version"><a href="https://github.com/eclipse-tractusx/digital-product-pass/releases/tag/digital-product-pass-2.1.3">2.1.3</a></pre>
 #### Application Version
-<pre id="app-version"><a href="https://github.com/eclipse-tractusx/digital-product-pass/releases/tag/v2.1.2">v2.1.2</a></pre>
+<pre id="app-version"><a href="https://github.com/eclipse-tractusx/digital-product-pass/releases/tag/v2.1.3">v2.1.3</a></pre>
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- 
-  Catena-X - Digital Product Passport Application 
+  Tractus-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,7 @@
 <!-- 
-  Catena-X - Digital Product Passport Application 
+  Tractus-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/buildAndDeploy.sh
+++ b/buildAndDeploy.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/charts/digital-product-pass/.helmignore
+++ b/charts/digital-product-pass/.helmignore
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/charts/digital-product-pass/Chart.yaml
+++ b/charts/digital-product-pass/Chart.yaml
@@ -41,10 +41,10 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 2.1.2
+version: 2.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.1.2"
+appVersion: "2.1.3"

--- a/charts/digital-product-pass/Chart.yaml
+++ b/charts/digital-product-pass/Chart.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/charts/digital-product-pass/LICENSE
+++ b/charts/digital-product-pass/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA      
+   Copyright 2022, 2023 BMW AG, Henkel AG & Co. KGaA      
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/charts/digital-product-pass/LICENSE
+++ b/charts/digital-product-pass/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022, 2023 BMW AG, Henkel AG & Co. KGaA      
+   Copyright 2022, 2024 BMW AG, Henkel AG & Co. KGaA      
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/charts/digital-product-pass/README.md
+++ b/charts/digital-product-pass/README.md
@@ -23,7 +23,7 @@
 
 # digital-product-pass
 
-![Version: 2.1.2](https://img.shields.io/badge/Version-2.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.2](https://img.shields.io/badge/AppVersion-2.1.2-informational?style=flat-square)
+![Version: 2.1.3](https://img.shields.io/badge/Version-2.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.3](https://img.shields.io/badge/AppVersion-2.1.3-informational?style=flat-square)
 
 A Helm chart for Tractus-X Digital Product Pass Kubernetes
 

--- a/charts/digital-product-pass/README.md
+++ b/charts/digital-product-pass/README.md
@@ -1,7 +1,7 @@
 <!-- 
-  Catena-X - Digital Product Passport Application 
+  Tractus-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/charts/digital-product-pass/templates/_helpers.tpl
+++ b/charts/digital-product-pass/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/charts/digital-product-pass/templates/configmap-backend.yaml
+++ b/charts/digital-product-pass/templates/configmap-backend.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/charts/digital-product-pass/templates/deployment-backend.yaml
+++ b/charts/digital-product-pass/templates/deployment-backend.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/charts/digital-product-pass/templates/deployment-frontend.yaml
+++ b/charts/digital-product-pass/templates/deployment-frontend.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/charts/digital-product-pass/templates/ingress-backend.yaml
+++ b/charts/digital-product-pass/templates/ingress-backend.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
   #
-  # Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  # Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
   #
   # See the NOTICE file(s) distributed with this work for additional

--- a/charts/digital-product-pass/templates/ingress-frontend.yaml
+++ b/charts/digital-product-pass/templates/ingress-frontend.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
   #
-  # Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  # Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
   #
   # See the NOTICE file(s) distributed with this work for additional

--- a/charts/digital-product-pass/templates/pvc-data.yaml
+++ b/charts/digital-product-pass/templates/pvc-data.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/charts/digital-product-pass/templates/secret-backend.yaml
+++ b/charts/digital-product-pass/templates/secret-backend.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/charts/digital-product-pass/templates/service-backend.yaml
+++ b/charts/digital-product-pass/templates/service-backend.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/charts/digital-product-pass/templates/service-frontend.yaml
+++ b/charts/digital-product-pass/templates/service-frontend.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/charts/digital-product-pass/templates/tests/test-dpp-connection.yaml
+++ b/charts/digital-product-pass/templates/tests/test-dpp-connection.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/charts/digital-product-pass/values-beta.yaml
+++ b/charts/digital-product-pass/values-beta.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/charts/digital-product-pass/values-dev.yaml
+++ b/charts/digital-product-pass/values-dev.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/charts/digital-product-pass/values-int.yaml
+++ b/charts/digital-product-pass/values-int.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/charts/digital-product-pass/values.yaml
+++ b/charts/digital-product-pass/values.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,7 +1,7 @@
 /**
- * Catena-X -  Digital Product Passport Application
+ * Tractus-X -  Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/cypress/e2e/sign-in/e2e.cy.js
+++ b/cypress/e2e/sign-in/e2e.cy.js
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,7 +1,7 @@
 <!-- 
-  Catena-X - Digital Product Passport Application 
+  Tractus-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/deployment/infrastructure/edc-consumer/Chart.yaml
+++ b/deployment/infrastructure/edc-consumer/Chart.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/deployment/infrastructure/edc-consumer/README.md
+++ b/deployment/infrastructure/edc-consumer/README.md
@@ -1,7 +1,7 @@
 <!-- 
-  Catena-X - Digital Product Passport Application 
+  Tractus-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/deployment/infrastructure/edc-consumer/values-beta.yaml
+++ b/deployment/infrastructure/edc-consumer/values-beta.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/deployment/infrastructure/edc-consumer/values-int.yaml
+++ b/deployment/infrastructure/edc-consumer/values-int.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/deployment/infrastructure/edc-consumer/values.yaml
+++ b/deployment/infrastructure/edc-consumer/values.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/deployment/infrastructure/edc-provider/Chart.yaml
+++ b/deployment/infrastructure/edc-provider/Chart.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/deployment/infrastructure/edc-provider/README.md
+++ b/deployment/infrastructure/edc-provider/README.md
@@ -1,7 +1,7 @@
 <!-- 
-  Catena-X - Digital Product Passport Application 
+  Tractus-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/deployment/infrastructure/edc-provider/data-service/.helmignore
+++ b/deployment/infrastructure/edc-provider/data-service/.helmignore
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/deployment/infrastructure/edc-provider/data-service/Chart.yaml
+++ b/deployment/infrastructure/edc-provider/data-service/Chart.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/deployment/infrastructure/edc-provider/data-service/README.md
+++ b/deployment/infrastructure/edc-provider/data-service/README.md
@@ -1,7 +1,7 @@
 <!-- 
-  Catena-X - Digital Product Passport Application 
+  Tractus-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/deployment/infrastructure/edc-provider/data-service/templates/_helpers.tpl
+++ b/deployment/infrastructure/edc-provider/data-service/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/deployment/infrastructure/edc-provider/data-service/templates/deployment.yaml
+++ b/deployment/infrastructure/edc-provider/data-service/templates/deployment.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/deployment/infrastructure/edc-provider/data-service/templates/ingress.yaml
+++ b/deployment/infrastructure/edc-provider/data-service/templates/ingress.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
   #
-  # Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  # Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
   #
   # See the NOTICE file(s) distributed with this work for additional

--- a/deployment/infrastructure/edc-provider/data-service/templates/service.yaml
+++ b/deployment/infrastructure/edc-provider/data-service/templates/service.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/deployment/infrastructure/edc-provider/data-service/values-beta.yaml
+++ b/deployment/infrastructure/edc-provider/data-service/values-beta.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/deployment/infrastructure/edc-provider/data-service/values-dev.yaml
+++ b/deployment/infrastructure/edc-provider/data-service/values-dev.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/deployment/infrastructure/edc-provider/data-service/values-int.yaml
+++ b/deployment/infrastructure/edc-provider/data-service/values-int.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/deployment/infrastructure/edc-provider/data-service/values.yaml
+++ b/deployment/infrastructure/edc-provider/data-service/values.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/deployment/infrastructure/edc-provider/values-beta.yaml
+++ b/deployment/infrastructure/edc-provider/values-beta.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/deployment/infrastructure/edc-provider/values-int.yaml
+++ b/deployment/infrastructure/edc-provider/values-int.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/deployment/infrastructure/edc-provider/values.yaml
+++ b/deployment/infrastructure/edc-provider/values.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/deployment/infrastructure/registry/Chart.yaml
+++ b/deployment/infrastructure/registry/Chart.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/deployment/infrastructure/registry/README.md
+++ b/deployment/infrastructure/registry/README.md
@@ -1,7 +1,7 @@
 <!-- 
-  Catena-X - Digital Product Passport Application 
+  Tractus-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/deployment/infrastructure/registry/values.yaml
+++ b/deployment/infrastructure/registry/values.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/deployment/local/docker/Keycloak/README.md
+++ b/deployment/local/docker/Keycloak/README.md
@@ -1,7 +1,7 @@
 <!-- 
-  Catena-X - Digital Product Passport Application 
+  Tractus-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/deployment/local/docker/README.md
+++ b/deployment/local/docker/README.md
@@ -1,7 +1,7 @@
 <!-- 
-  Catena-X - Digital Product Passport Application 
+  Tractus-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/deployment/local/postman/README.md
+++ b/deployment/local/postman/README.md
@@ -1,7 +1,7 @@
 <!-- 
-  Catena-X - Digital Product Passport Application 
+  Tractus-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/deployment/local/scripts/init-values.sh
+++ b/deployment/local/scripts/init-values.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/deployment/local/storage/pv-data.yaml
+++ b/deployment/local/storage/pv-data.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/deployment/local/storage/pvc-data.yaml
+++ b/deployment/local/storage/pvc-data.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/deployment/local/testing/README.md
+++ b/deployment/local/testing/README.md
@@ -1,7 +1,7 @@
 <!-- 
-  Catena-X - Digital Product Passport Application 
+  Tractus-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/deployment/local/testing/delete-testdata.sh
+++ b/deployment/local/testing/delete-testdata.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/deployment/local/testing/functions.sh
+++ b/deployment/local/testing/functions.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/deployment/local/testing/transform-and-upload.sh
+++ b/deployment/local/testing/transform-and-upload.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/deployment/local/testing/upload-testdata.sh
+++ b/deployment/local/testing/upload-testdata.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -1,7 +1,7 @@
 <!-- 
-  Catena-X - Digital Product Passport Application 
+  Tractus-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional
@@ -271,6 +271,6 @@ _integration_ (`https://dpp.int.demo.catena-x.net/`) environments.
 This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 - SPDX-License-Identifier: Apache-2.0
-- SPDX-FileCopyrightText: 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+- SPDX-FileCopyrightText: 2022, 2023 BMW AG, Henkel AG & Co. KGaA
 - SPDX-FileCopyrightText: 2023, 2024 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/digital-product-pass

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -271,6 +271,6 @@ _integration_ (`https://dpp.int.demo.catena-x.net/`) environments.
 This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 - SPDX-License-Identifier: Apache-2.0
-- SPDX-FileCopyrightText: 2022, 2023 BMW AG, Henkel AG & Co. KGaA
+- SPDX-FileCopyrightText: 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 - SPDX-FileCopyrightText: 2023, 2024 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/digital-product-pass

--- a/docs/IaC.md
+++ b/docs/IaC.md
@@ -73,6 +73,6 @@ Please see more details about Veracode tool integration [here](https://catenax-n
 This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 - SPDX-License-Identifier: Apache-2.0
-- SPDX-FileCopyrightText: 2022, 2023 BMW AG, Henkel AG & Co. KGaA
+- SPDX-FileCopyrightText: 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 - SPDX-FileCopyrightText: 2023 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/digital-product-pass

--- a/docs/IaC.md
+++ b/docs/IaC.md
@@ -1,7 +1,7 @@
 <!-- 
-  Catena-X - Digital Product Passport Application 
+  Tractus-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional
@@ -73,6 +73,6 @@ Please see more details about Veracode tool integration [here](https://catenax-n
 This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 - SPDX-License-Identifier: Apache-2.0
-- SPDX-FileCopyrightText: 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+- SPDX-FileCopyrightText: 2022, 2023 BMW AG, Henkel AG & Co. KGaA
 - SPDX-FileCopyrightText: 2023 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/digital-product-pass

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,7 +46,7 @@ Welcome to the documentation section, below you will find all the necesary docs 
 - [API Documentation](#api-documentation)
   - [Postman Collection](#postman-collection)
   - [Swagger Documetation](#swagger-documetation)
-- [NOTICE](#notice)
+  - [NOTICE](#notice)
 <!-- TOC -->
 
 
@@ -207,6 +207,6 @@ You can also deploy the application using the [deployment guidelines](./GETTING-
 This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 - SPDX-License-Identifier: Apache-2.0
-- SPDX-FileCopyrightText: 2022, 2023 BMW AG, Henkel AG & Co. KGaA
+- SPDX-FileCopyrightText: 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 - SPDX-FileCopyrightText: 2023, 2024 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/digital-product-pass

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 <!-- 
-  Catena-X - Digital Product Passport Application 
+  Tractus-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional
@@ -207,6 +207,6 @@ You can also deploy the application using the [deployment guidelines](./GETTING-
 This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 - SPDX-License-Identifier: Apache-2.0
-- SPDX-FileCopyrightText: 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+- SPDX-FileCopyrightText: 2022, 2023 BMW AG, Henkel AG & Co. KGaA
 - SPDX-FileCopyrightText: 2023, 2024 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/digital-product-pass

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -52,6 +52,6 @@ Navigate to the [Deploymment Guide](/deployment/README.md) and follow the steps.
 This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 - SPDX-License-Identifier: Apache-2.0
-- SPDX-FileCopyrightText: 2022, 2023 BMW AG, Henkel AG & Co. KGaA
+- SPDX-FileCopyrightText: 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 - SPDX-FileCopyrightText: 2023 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/digital-product-pass

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,7 +1,7 @@
 <!-- 
-  Catena-X - Digital Product Passport Application 
+  Tractus-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional
@@ -52,6 +52,6 @@ Navigate to the [Deploymment Guide](/deployment/README.md) and follow the steps.
 This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 - SPDX-License-Identifier: Apache-2.0
-- SPDX-FileCopyrightText: 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+- SPDX-FileCopyrightText: 2022, 2023 BMW AG, Henkel AG & Co. KGaA
 - SPDX-FileCopyrightText: 2023 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/digital-product-pass

--- a/docs/RELEASE_USER.md
+++ b/docs/RELEASE_USER.md
@@ -1,7 +1,7 @@
 <!-- 
-  Catena-X - Digital Product Passport Application 
+  Tractus-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional
@@ -500,6 +500,6 @@ A deep dive on the application's operation and functionalities can be found in t
 This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 - SPDX-License-Identifier: Apache-2.0
-- SPDX-FileCopyrightText: 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+- SPDX-FileCopyrightText: 2022, 2023 BMW AG, Henkel AG & Co. KGaA
 - SPDX-FileCopyrightText: 2023 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/digital-product-pass

--- a/docs/RELEASE_USER.md
+++ b/docs/RELEASE_USER.md
@@ -24,6 +24,20 @@
 # Release Notes Digital Product Pass Application
 User friendly relase notes without especific technical details.
 
+**February 19 2024 (Version 2.1.3)**
+*19.02.2024*
+
+### Updated
+
+#### Removed BASF from header licences and license
+There was a request from the company BASF to remove their company name from the copyright notice and license information.
+
+#### Updated copyright header to Tractus-X instead of Catena-X
+In the copyright headers the Digital Product Pass still had the name "Catena-X". It was removed to comply with the TRGs for legal licenses.
+
+
+
+
 **February 16 2024 (Version 2.1.2)**
 *16.02.2024*
 
@@ -500,6 +514,6 @@ A deep dive on the application's operation and functionalities can be found in t
 This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 - SPDX-License-Identifier: Apache-2.0
-- SPDX-FileCopyrightText: 2022, 2023 BMW AG, Henkel AG & Co. KGaA
+- SPDX-FileCopyrightText: 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 - SPDX-FileCopyrightText: 2023 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/digital-product-pass

--- a/docs/SECRETS_MANAGEMENT.md
+++ b/docs/SECRETS_MANAGEMENT.md
@@ -122,6 +122,6 @@ Setting up Git Guradian for the project [gitguardian-shield](https://docs.gitgua
 This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 - SPDX-License-Identifier: Apache-2.0
-- SPDX-FileCopyrightText: 2022, 2023 BMW AG, Henkel AG & Co. KGaA
+- SPDX-FileCopyrightText: 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 - SPDX-FileCopyrightText: 2023 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/digital-product-pass

--- a/docs/SECRETS_MANAGEMENT.md
+++ b/docs/SECRETS_MANAGEMENT.md
@@ -1,7 +1,7 @@
 <!-- 
-  Catena-X - Digital Product Passport Application 
+  Tractus-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional
@@ -122,6 +122,6 @@ Setting up Git Guradian for the project [gitguardian-shield](https://docs.gitgua
 This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 - SPDX-License-Identifier: Apache-2.0
-- SPDX-FileCopyrightText: 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+- SPDX-FileCopyrightText: 2022, 2023 BMW AG, Henkel AG & Co. KGaA
 - SPDX-FileCopyrightText: 2023 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/digital-product-pass

--- a/docs/admin guide/Admin_Guide.md
+++ b/docs/admin guide/Admin_Guide.md
@@ -1,7 +1,7 @@
 <!-- 
-  Catena-X - Digital Product Passport Application 
+  Tractus-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional
@@ -589,7 +589,7 @@ The rest of the assets can be configured in the same way as the normal assets.
 This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 - SPDX-License-Identifier: Apache-2.0
-- SPDX-FileCopyrightText: 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+- SPDX-FileCopyrightText: 2022, 2023 BMW AG, Henkel AG & Co. KGaA
 - SPDX-FileCopyrightText: 2023, 2024 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/digital-product-pass
 

--- a/docs/admin guide/Admin_Guide.md
+++ b/docs/admin guide/Admin_Guide.md
@@ -589,7 +589,7 @@ The rest of the assets can be configured in the same way as the normal assets.
 This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 - SPDX-License-Identifier: Apache-2.0
-- SPDX-FileCopyrightText: 2022, 2023 BMW AG, Henkel AG & Co. KGaA
+- SPDX-FileCopyrightText: 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 - SPDX-FileCopyrightText: 2023, 2024 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/digital-product-pass
 

--- a/docs/arc42/Arc42.md
+++ b/docs/arc42/Arc42.md
@@ -445,7 +445,7 @@ The Job parameters (*jobId, globalAssetId, jobStatus*) will be stored in the `me
 The backend will also create a single node tree for the Digital Twin that is already available. Creating a `treeDataModel.json` file at the process directory.
 
 ##### Search API Sequence with IRS
-![IRS Search Sequence](./media/irs/searchWithIRS.drawio.svg)
+![IRS Search Sequence](./media/irs/searchWithIrs.drawio.svg)
 
 ##### Search API Flow with IRS
 ![IRS Search Flow](media/irs/irsSearchFlow.drawio.svg)
@@ -811,6 +811,6 @@ An user needs to be able to understand easily the application interface, in orde
 This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 - SPDX-License-Identifier: Apache-2.0
-- SPDX-FileCopyrightText: 2022, 2023 BMW AG, Henkel AG & Co. KGaA
+- SPDX-FileCopyrightText: 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 - SPDX-FileCopyrightText: 2023, 2024 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/digital-product-pass

--- a/docs/arc42/Arc42.md
+++ b/docs/arc42/Arc42.md
@@ -1,7 +1,7 @@
 <!-- 
-  Catena-X - Digital Product Passport Application 
+  Tractus-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional
@@ -527,7 +527,7 @@ Alternatively (or additionally) you can use a table. The title of the table is t
 * Source code management - GitHub Repository:
   * [https://github.com/eclipse-tractusx/digital-product-pass](https://github.com/eclipse-tractusx/digital-product-pass)
 * DevSecOps:
-  * [Intro | Catena-x - DevSecOps](https://catenax-ng.github.io/docs/getstarted/intro)
+  * [Intro | Tractus-X - DevSecOps](https://catenax-ng.github.io/docs/getstarted/intro)
 * Eclipse Tractus-X Release Guidelines:
   * [Intro | Eclipse Tractus-X - Release Guidelines](https://eclipse-tractusx.github.io/docs/release)
 
@@ -811,6 +811,6 @@ An user needs to be able to understand easily the application interface, in orde
 This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 - SPDX-License-Identifier: Apache-2.0
-- SPDX-FileCopyrightText: 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+- SPDX-FileCopyrightText: 2022, 2023 BMW AG, Henkel AG & Co. KGaA
 - SPDX-FileCopyrightText: 2023, 2024 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/digital-product-pass

--- a/docs/business statement/Business Statement.md
+++ b/docs/business statement/Business Statement.md
@@ -1,7 +1,7 @@
 <!-- 
-  Catena-X - Digital Product Passport Application 
+  Tractus-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional
@@ -91,6 +91,6 @@ The following candidates are not yet implemented:
 This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 - SPDX-License-Identifier: Apache-2.0
-- SPDX-FileCopyrightText: 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+- SPDX-FileCopyrightText: 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 - SPDX-FileCopyrightText: 2023, 2024 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/digital-product-pass

--- a/docs/cypress/CYPRESS.md
+++ b/docs/cypress/CYPRESS.md
@@ -55,6 +55,6 @@ This is the documentation for Battery Passport App E2E Cypress test.
 This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 - SPDX-License-Identifier: Apache-2.0
-- SPDX-FileCopyrightText: 2022, 2023 BMW AG, Henkel AG & Co. KGaA
+- SPDX-FileCopyrightText: 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 - SPDX-FileCopyrightText: 2023 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/digital-product-pass

--- a/docs/cypress/CYPRESS.md
+++ b/docs/cypress/CYPRESS.md
@@ -1,7 +1,7 @@
 <!-- 
-  Catena-X - Digital Product Passport Application 
+  Tractus-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional
@@ -55,6 +55,6 @@ This is the documentation for Battery Passport App E2E Cypress test.
 This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 - SPDX-License-Identifier: Apache-2.0
-- SPDX-FileCopyrightText: 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+- SPDX-FileCopyrightText: 2022, 2023 BMW AG, Henkel AG & Co. KGaA
 - SPDX-FileCopyrightText: 2023 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/digital-product-pass

--- a/docs/data retrieval guide/DataRetrievalGuide.md
+++ b/docs/data retrieval guide/DataRetrievalGuide.md
@@ -1,7 +1,7 @@
 <!-- 
-  Catena-X - Digital Product Passport Application 
+  Tractus-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional
@@ -423,7 +423,7 @@ Here are the main authors and reviewers of this documentation:
 This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 - SPDX-License-Identifier: Apache-2.0
-- SPDX-FileCopyrightText: 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+- SPDX-FileCopyrightText: 2022, 2023 BMW AG, Henkel AG & Co. KGaA
 - SPDX-FileCopyrightText: 2023 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/digital-product-pass
 

--- a/docs/data retrieval guide/DataRetrievalGuide.md
+++ b/docs/data retrieval guide/DataRetrievalGuide.md
@@ -423,7 +423,7 @@ Here are the main authors and reviewers of this documentation:
 This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 - SPDX-License-Identifier: Apache-2.0
-- SPDX-FileCopyrightText: 2022, 2023 BMW AG, Henkel AG & Co. KGaA
+- SPDX-FileCopyrightText: 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 - SPDX-FileCopyrightText: 2023 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/digital-product-pass
 

--- a/docs/notice.md
+++ b/docs/notice.md
@@ -1,7 +1,7 @@
 <!-- 
-  Catena-X - Digital Product Passport Application 
+  Tractus-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/docs/user manual/User Manual Product Viewer App.md
+++ b/docs/user manual/User Manual Product Viewer App.md
@@ -223,6 +223,6 @@ In the below figure, the product battery contains one child component (13) named
 This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 - SPDX-License-Identifier: Apache-2.0
-- SPDX-FileCopyrightText: 2022, 2023 BMW AG, Henkel AG & Co KGaA
+- SPDX-FileCopyrightText: 2022, 2024 BMW AG, Henkel AG & Co KGaA
 - SPDX-FileCopyrightText: 2023, 2024 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/digital-product-pass

--- a/docs/user manual/User Manual Product Viewer App.md
+++ b/docs/user manual/User Manual Product Viewer App.md
@@ -1,7 +1,7 @@
 <!-- 
-  Catena-X - Digital Product Passport Application 
+  Tractus-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional
@@ -223,6 +223,6 @@ In the below figure, the product battery contains one child component (13) named
 This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 - SPDX-License-Identifier: Apache-2.0
-- SPDX-FileCopyrightText: 2022, 2023 BASF SE, BMW AG, Henkel AG & Co KGaA
+- SPDX-FileCopyrightText: 2022, 2023 BMW AG, Henkel AG & Co KGaA
 - SPDX-FileCopyrightText: 2023, 2024 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/digital-product-pass

--- a/dpp-backend/charts/digital-product-pass-backend/.helmignore
+++ b/dpp-backend/charts/digital-product-pass-backend/.helmignore
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/charts/digital-product-pass-backend/Chart.yaml
+++ b/dpp-backend/charts/digital-product-pass-backend/Chart.yaml
@@ -41,10 +41,10 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 2.1.2
+version: 2.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.1.2"
+appVersion: "2.1.3"

--- a/dpp-backend/charts/digital-product-pass-backend/Chart.yaml
+++ b/dpp-backend/charts/digital-product-pass-backend/Chart.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/charts/digital-product-pass-backend/LICENSE
+++ b/dpp-backend/charts/digital-product-pass-backend/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA      
+   Copyright 2022, 2023 BMW AG, Henkel AG & Co. KGaA      
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/dpp-backend/charts/digital-product-pass-backend/LICENSE
+++ b/dpp-backend/charts/digital-product-pass-backend/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022, 2023 BMW AG, Henkel AG & Co. KGaA      
+   Copyright 2022, 2024 BMW AG, Henkel AG & Co. KGaA      
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/dpp-backend/charts/digital-product-pass-backend/README.md
+++ b/dpp-backend/charts/digital-product-pass-backend/README.md
@@ -23,7 +23,7 @@
 
 # digital-product-pass-backend
 
-![Version: 2.1.2](https://img.shields.io/badge/Version-2.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.2](https://img.shields.io/badge/AppVersion-2.1.2-informational?style=flat-square)
+![Version: 2.1.3](https://img.shields.io/badge/Version-2.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.3](https://img.shields.io/badge/AppVersion-2.1.3-informational?style=flat-square)
 
 A Helm chart for Tractus-X Digital Product Pass Backend Kubernetes
 

--- a/dpp-backend/charts/digital-product-pass-backend/README.md
+++ b/dpp-backend/charts/digital-product-pass-backend/README.md
@@ -1,7 +1,7 @@
 <!-- 
-  Catena-X - Digital Product Passport Application 
+  Tractus-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/charts/digital-product-pass-backend/templates/NOTES.txt
+++ b/dpp-backend/charts/digital-product-pass-backend/templates/NOTES.txt
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/charts/digital-product-pass-backend/templates/_helpers.tpl
+++ b/dpp-backend/charts/digital-product-pass-backend/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 #####################################################################################
-    # Catena-X - Digital Product Passport Application
+    # Tractus-X - Digital Product Passport Application
     #
-    # Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+    # Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
     # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
     #
     # See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/charts/digital-product-pass-backend/templates/configmap.yaml
+++ b/dpp-backend/charts/digital-product-pass-backend/templates/configmap.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/charts/digital-product-pass-backend/templates/deployment.yaml
+++ b/dpp-backend/charts/digital-product-pass-backend/templates/deployment.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/charts/digital-product-pass-backend/templates/ingress.yaml
+++ b/dpp-backend/charts/digital-product-pass-backend/templates/ingress.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
   #
-  # Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  # Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
   #
   # See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/charts/digital-product-pass-backend/templates/pvc-data.yaml
+++ b/dpp-backend/charts/digital-product-pass-backend/templates/pvc-data.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/charts/digital-product-pass-backend/templates/secret.yaml
+++ b/dpp-backend/charts/digital-product-pass-backend/templates/secret.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/charts/digital-product-pass-backend/templates/service.yaml
+++ b/dpp-backend/charts/digital-product-pass-backend/templates/service.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/charts/digital-product-pass-backend/templates/serviceaccount.yaml
+++ b/dpp-backend/charts/digital-product-pass-backend/templates/serviceaccount.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/charts/digital-product-pass-backend/templates/tests/test-connection.yaml
+++ b/dpp-backend/charts/digital-product-pass-backend/templates/tests/test-connection.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/charts/digital-product-pass-backend/values-dev.yaml
+++ b/dpp-backend/charts/digital-product-pass-backend/values-dev.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/charts/digital-product-pass-backend/values-int.yaml
+++ b/dpp-backend/charts/digital-product-pass-backend/values-int.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/charts/digital-product-pass-backend/values.yaml
+++ b/dpp-backend/charts/digital-product-pass-backend/values.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/.gitattributes
+++ b/dpp-backend/digitalproductpass/.gitattributes
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/.gitignore
+++ b/dpp-backend/digitalproductpass/.gitignore
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/Dockerfile
+++ b/dpp-backend/digitalproductpass/Dockerfile
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/README.md
+++ b/dpp-backend/digitalproductpass/README.md
@@ -24,7 +24,7 @@
 <h1 style="display:flex; align-items: center;"><img src="../../docs/catena-x-logo.svg"/>&nbsp;&nbsp;Digital Product Pass Backend</h1>
 
 
-<h2><strong>Version</strong>: <span style="color: cyan">v2.1.2</span><h2>
+<h2><strong>Version</strong>: <span style="color: cyan">v2.1.3</span><h2>
 
 <br>
 

--- a/dpp-backend/digitalproductpass/README.md
+++ b/dpp-backend/digitalproductpass/README.md
@@ -1,7 +1,7 @@
 <!-- 
-  Catena-X - Digital Product Passport Application 
+  Tractus-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/deploy.sh
+++ b/dpp-backend/digitalproductpass/deploy.sh
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/docs/tests/UNIT_TESTS.md
+++ b/dpp-backend/digitalproductpass/docs/tests/UNIT_TESTS.md
@@ -1,7 +1,7 @@
 <!-- 
-  Catena-X - Digital Product Passport Application 
+  Tractus-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/mvnw
+++ b/dpp-backend/digitalproductpass/mvnw
@@ -1,8 +1,8 @@
 #!/bin/sh
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/mvnw.cmd
+++ b/dpp-backend/digitalproductpass/mvnw.cmd
@@ -1,4 +1,4 @@
-rem Copyright (c) 2022, 2023 BMW AG, Henkel AG & Co. KGaA
+rem Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 rem Copyright (c) 2022, 2023 Contributors to the CatenaX (ng) GitHub Organisation.
 
 rem Licensed under the Apache License, Version 2.0 (the "License");

--- a/dpp-backend/digitalproductpass/mvnw.cmd
+++ b/dpp-backend/digitalproductpass/mvnw.cmd
@@ -1,4 +1,4 @@
-rem Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+rem Copyright (c) 2022, 2023 BMW AG, Henkel AG & Co. KGaA
 rem Copyright (c) 2022, 2023 Contributors to the CatenaX (ng) GitHub Organisation.
 
 rem Licensed under the Apache License, Version 2.0 (the "License");

--- a/dpp-backend/digitalproductpass/pom.xml
+++ b/dpp-backend/digitalproductpass/pom.xml
@@ -34,7 +34,7 @@
     </parent>
     <groupId>org.eclipse.tractusx</groupId>
     <artifactId>digitalproductpass</artifactId>
-    <version>2.1.2</version>
+    <version>2.1.3</version>
     <packaging>jar</packaging>
     <name>Catena-X Digital Product Passport Backend</name>
     <description>Digital Product Passport Consumer Backend Reference Implementation System for Product Passport Consumer Frontend Application

--- a/dpp-backend/digitalproductpass/pom.xml
+++ b/dpp-backend/digitalproductpass/pom.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~
-  ~ Catena-X - Digital Product Pass Application
+  ~ Tractus-X - Digital Product Pass Application
   ~
-  ~ Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  ~ Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   ~ Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   ~ See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/Application.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/Application.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/AppConfig.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/AppConfig.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/DiscoveryConfig.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/DiscoveryConfig.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/DtrConfig.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/DtrConfig.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/IrsConfig.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/IrsConfig.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/PassportConfig.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/PassportConfig.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/ProcessConfig.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/ProcessConfig.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/SecurityConfig.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/SecurityConfig.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/ThreadConfig.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/ThreadConfig.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/VaultConfig.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/VaultConfig.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/WebConfig.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/config/WebConfig.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/exceptions/ConfigException.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/exceptions/ConfigException.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/exceptions/ControllerException.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/exceptions/ControllerException.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/exceptions/DataModelException.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/exceptions/DataModelException.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/exceptions/ManagerException.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/exceptions/ManagerException.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/exceptions/ServiceException.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/exceptions/ServiceException.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/exceptions/ServiceInitializationException.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/exceptions/ServiceInitializationException.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/http/controllers/AppController.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/http/controllers/AppController.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/http/controllers/api/ApiController.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/http/controllers/api/ApiController.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/http/controllers/api/ContractController.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/http/controllers/api/ContractController.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/http/controllers/api/IrsController.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/http/controllers/api/IrsController.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/http/controllers/auth/AuthController.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/http/controllers/auth/AuthController.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/http/controllers/error/ErrorResponseController.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/http/controllers/error/ErrorResponseController.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/http/middleware/BaseInterceptor.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/http/middleware/BaseInterceptor.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/http/middleware/InterceptorConfig.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/http/middleware/InterceptorConfig.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/interfaces/ServiceInitializationInterface.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/interfaces/ServiceInitializationInterface.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/listeners/AppListener.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/listeners/AppListener.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *
@@ -208,7 +208,7 @@ public class AppListener {
         String serverStartUpMessage = "\n\n" +
                 "**********************************************************************\n\n" +
                 " " + buildProperties.getName() + "\n" +
-                " Copyright (c) 2022, 2024: BASF SE, BMW AG, Henkel AG & Co. KGaA\n" +
+                " Copyright (c) 2022, 2024: BMW AG, Henkel AG & Co. KGaA\n" +
                 " Copyright (c) 2022, 2024: Contributors to the Eclipse Foundation.\n\n" +
                 "**********************************************************************\n\n";
         System.out.print(serverStartUpMessage);

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/managers/DtrSearchManager.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/managers/DtrSearchManager.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/managers/ProcessDataModel.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/managers/ProcessDataModel.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/managers/ProcessManager.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/managers/ProcessManager.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/managers/TreeManager.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/managers/TreeManager.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/auth/Credential.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/auth/Credential.java
@@ -27,7 +27,7 @@
  *
  * Tractus-X - Product Passport Consumer Backend
  *
- * Copyright (c) 2022, 2023 BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/auth/Credential.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/auth/Credential.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *
@@ -25,9 +25,9 @@
 
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Tractus-X - Product Passport Consumer Backend
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2023 BMW AG, Henkel AG & Co. KGaA
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/auth/JwtToken.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/auth/JwtToken.java
@@ -27,7 +27,7 @@
  *
  * Tractus-X - Product Passport Consumer Backend
  *
- * Copyright (c) 2022, 2023 BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/auth/JwtToken.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/auth/JwtToken.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *
@@ -25,9 +25,9 @@
 
 /*********************************************************************************
  *
- * Catena-X - Product Passport Consumer Backend
+ * Tractus-X - Product Passport Consumer Backend
  *
- * Copyright (c) 2022, 2023 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2023 BMW AG, Henkel AG & Co. KGaA
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/auth/UserCredential.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/auth/UserCredential.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/auth/UserInfo.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/auth/UserInfo.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/catenax/BpnDiscovery.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/catenax/BpnDiscovery.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/catenax/Discovery.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/catenax/Discovery.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/catenax/Dtr.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/catenax/Dtr.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/catenax/EdcDiscoveryEndpoint.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/catenax/EdcDiscoveryEndpoint.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/dtregistry/DigitalTwin.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/dtregistry/DigitalTwin.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/dtregistry/EndPoint.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/dtregistry/EndPoint.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/dtregistry/SubModel.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/dtregistry/SubModel.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/edc/AssetSearch.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/edc/AssetSearch.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/edc/DataPlaneEndpoint.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/edc/DataPlaneEndpoint.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/edc/Jwt.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/edc/Jwt.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/http/Response.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/http/Response.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/http/requests/DiscoverySearch.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/http/requests/DiscoverySearch.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/http/requests/Search.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/http/requests/Search.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/http/requests/TokenRequest.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/http/requests/TokenRequest.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/http/responses/IdResponse.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/http/responses/IdResponse.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/irs/Job.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/irs/Job.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/irs/JobHistory.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/irs/JobHistory.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/irs/JobRequest.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/irs/JobRequest.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/irs/JobResponse.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/irs/JobResponse.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/irs/Relationship.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/irs/Relationship.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/manager/History.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/manager/History.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/manager/Node.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/manager/Node.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/manager/NodeComponent.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/manager/NodeComponent.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/manager/Process.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/manager/Process.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/manager/SearchStatus.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/manager/SearchStatus.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/manager/Status.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/manager/Status.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Catalog.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Catalog.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/CatalogRequest.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/CatalogRequest.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Constraint.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Constraint.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/DataService.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/DataService.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Dataset.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Dataset.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/DidDocument.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/DidDocument.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Distribution.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Distribution.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/EdcResponse.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/EdcResponse.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Negotiation.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Negotiation.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/NegotiationRequest.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/NegotiationRequest.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Offer.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Offer.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Properties.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Properties.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Set.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Set.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Transfer.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/Transfer.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/TransferRequest.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/negotiation/TransferRequest.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/passports/PassportResponse.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/passports/PassportResponse.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/service/BaseService.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/service/BaseService.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/AasService.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/AasService.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/AuthenticationService.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/AuthenticationService.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/CatenaXService.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/CatenaXService.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/DataPlaneService.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/DataPlaneService.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/DataTransferService.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/DataTransferService.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/IrsService.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/IrsService.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/VaultService.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/VaultService.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/utils/CatenaXUtil.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/CatenaXUtil.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/utils/CrypUtil.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/CrypUtil.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/utils/CsvUtil.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/CsvUtil.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/utils/DateTimeUtil.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/DateTimeUtil.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/utils/EdcUtil.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/EdcUtil.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/utils/FileUtil.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/FileUtil.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/utils/HttpUtil.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/HttpUtil.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/utils/JsonUtil.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/JsonUtil.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/utils/LogUtil.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/LogUtil.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/utils/NumericUtil.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/NumericUtil.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/utils/PassportUtil.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/PassportUtil.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/utils/ReflectionUtil.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/ReflectionUtil.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/utils/StringUtil.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/StringUtil.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/utils/SystemUtil.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/SystemUtil.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/utils/ThreadUtil.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/ThreadUtil.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/utils/YamlUtil.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/YamlUtil.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/java/utils/exceptions/UtilException.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/exceptions/UtilException.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/main/resources/application.yml
+++ b/dpp-backend/digitalproductpass/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/src/main/resources/logback-spring.xml
+++ b/dpp-backend/digitalproductpass/src/main/resources/logback-spring.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~
-  ~ Catena-X - Digital Product Pass Application
+  ~ Tractus-X - Digital Product Pass Application
   ~
-  ~ Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  ~ Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   ~ Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   ~ See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/digitalproductpass/src/test/java/managers/DtrSearchManagerTest.java
+++ b/dpp-backend/digitalproductpass/src/test/java/managers/DtrSearchManagerTest.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Pass Application
+ * Tractus-X - Digital Product Pass Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/test/java/managers/ProcessDataModelTest.java
+++ b/dpp-backend/digitalproductpass/src/test/java/managers/ProcessDataModelTest.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Pass Application
+ * Tractus-X - Digital Product Pass Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/test/java/managers/ProcessManagerTest.java
+++ b/dpp-backend/digitalproductpass/src/test/java/managers/ProcessManagerTest.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Pass Application
+ * Tractus-X - Digital Product Pass Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/test/java/managers/TreeManagerTest.java
+++ b/dpp-backend/digitalproductpass/src/test/java/managers/TreeManagerTest.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Pass Application
+ * Tractus-X - Digital Product Pass Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/test/java/mocks/MockedHttpSession.java
+++ b/dpp-backend/digitalproductpass/src/test/java/mocks/MockedHttpSession.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Pass Application
+ * Tractus-X - Digital Product Pass Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/test/java/services/AasServiceTest.java
+++ b/dpp-backend/digitalproductpass/src/test/java/services/AasServiceTest.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Pass Application
+ * Tractus-X - Digital Product Pass Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/test/java/services/AuthenticationServiceTest.java
+++ b/dpp-backend/digitalproductpass/src/test/java/services/AuthenticationServiceTest.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Pass Application
+ * Tractus-X - Digital Product Pass Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/test/java/services/CatenaXServiceTest.java
+++ b/dpp-backend/digitalproductpass/src/test/java/services/CatenaXServiceTest.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Pass Application
+ * Tractus-X - Digital Product Pass Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/test/java/services/DataPlaneServiceTest.java
+++ b/dpp-backend/digitalproductpass/src/test/java/services/DataPlaneServiceTest.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Pass Application
+ * Tractus-X - Digital Product Pass Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/test/java/services/DataTransferServiceTest.java
+++ b/dpp-backend/digitalproductpass/src/test/java/services/DataTransferServiceTest.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Pass Application
+ * Tractus-X - Digital Product Pass Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/test/java/services/IrsServiceTest.java
+++ b/dpp-backend/digitalproductpass/src/test/java/services/IrsServiceTest.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Pass Application
+ * Tractus-X - Digital Product Pass Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/test/java/utils/CrypUtilTest.java
+++ b/dpp-backend/digitalproductpass/src/test/java/utils/CrypUtilTest.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Pass Application
+ * Tractus-X - Digital Product Pass Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/test/java/utils/JsonUtilTest.java
+++ b/dpp-backend/digitalproductpass/src/test/java/utils/JsonUtilTest.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Pass Application
+ * Tractus-X - Digital Product Pass Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/test/java/utils/LogUtilTest.java
+++ b/dpp-backend/digitalproductpass/src/test/java/utils/LogUtilTest.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Pass Application
+ * Tractus-X - Digital Product Pass Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/test/java/utils/SystemUtilTest.java
+++ b/dpp-backend/digitalproductpass/src/test/java/utils/SystemUtilTest.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Pass Application
+ * Tractus-X - Digital Product Pass Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/test/java/utils/YamlUtilTest.java
+++ b/dpp-backend/digitalproductpass/src/test/java/utils/YamlUtilTest.java
@@ -1,8 +1,8 @@
 /*********************************************************************************
  *
- * Catena-X - Digital Product Pass Application
+ * Tractus-X - Digital Product Pass Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  *

--- a/dpp-backend/digitalproductpass/src/test/resources/application-test.yml
+++ b/dpp-backend/digitalproductpass/src/test/resources/application-test.yml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/scripts/README.md
+++ b/dpp-backend/scripts/README.md
@@ -1,7 +1,7 @@
 <!-- 
-  Catena-X - Digital Product Passport Application 
+  Tractus-X - Digital Product Passport Application 
  
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/scripts/get-data.sh
+++ b/dpp-backend/scripts/get-data.sh
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/scripts/getPassport.py
+++ b/dpp-backend/scripts/getPassport.py
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/scripts/logging.ini
+++ b/dpp-backend/scripts/logging.ini
@@ -1,7 +1,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-; Catena-X - Digital Product Passport Application
+; Tractus-X - Digital Product Passport Application
 ;
-; Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+; Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 ; Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 ;
 ; See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/scripts/requirements.txt
+++ b/dpp-backend/scripts/requirements.txt
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/scripts/utilities/authentication.py
+++ b/dpp-backend/scripts/utilities/authentication.py
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X -  Digital Product Passport Application
+# Tractus-X -  Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/scripts/utilities/constants.py
+++ b/dpp-backend/scripts/utilities/constants.py
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/scripts/utilities/httpUtils.py
+++ b/dpp-backend/scripts/utilities/httpUtils.py
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/dpp-backend/scripts/utilities/operators.py
+++ b/dpp-backend/scripts/utilities/operators.py
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "digital-product-pass-frontend",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "digital-product-pass-frontend",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "dependencies": {
         "@mdi/font": "5.9.55",
         "@popperjs/core": "^2.11.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digital-product-pass-frontend",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "private": true,
   "scripts": {
     "serve": "vite --host localhost",

--- a/pre-commit-config.yaml
+++ b/pre-commit-config.yaml
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 #################################################################################
-# Catena-X - Digital Product Passport Application
+# Tractus-X - Digital Product Passport Application
 #
-# Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
 # Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/assets/plugins/vuetify.js
+++ b/src/assets/plugins/vuetify.js
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/assets/plugins/webfontloader.js
+++ b/src/assets/plugins/webfontloader.js
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/assets/styles/components/general/contractModal.scss
+++ b/src/assets/styles/components/general/contractModal.scss
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/assets/styles/components/general/dialog.scss
+++ b/src/assets/styles/components/general/dialog.scss
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/assets/styles/components/general/footer.scss
+++ b/src/assets/styles/components/general/footer.scss
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/assets/styles/components/general/header.scss
+++ b/src/assets/styles/components/general/header.scss
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/assets/styles/components/general/loading.scss
+++ b/src/assets/styles/components/general/loading.scss
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/assets/styles/components/general/notFound.scss
+++ b/src/assets/styles/components/general/notFound.scss
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/assets/styles/components/general/recursiveTree.scss
+++ b/src/assets/styles/components/general/recursiveTree.scss
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/assets/styles/components/general/search.scss
+++ b/src/assets/styles/components/general/search.scss
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/assets/styles/components/general/tooltip.scss
+++ b/src/assets/styles/components/general/tooltip.scss
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/assets/styles/components/landing/searchView.scss
+++ b/src/assets/styles/components/landing/searchView.scss
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/assets/styles/components/passport/additionalData.scss
+++ b/src/assets/styles/components/passport/additionalData.scss
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/assets/styles/components/passport/cards.scss
+++ b/src/assets/styles/components/passport/cards.scss
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/assets/styles/components/passport/documentField.scss
+++ b/src/assets/styles/components/passport/documentField.scss
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/assets/styles/components/passport/elementChart.scss
+++ b/src/assets/styles/components/passport/elementChart.scss
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/assets/styles/components/passport/field.scss
+++ b/src/assets/styles/components/passport/field.scss
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/assets/styles/components/passport/passportPage.scss
+++ b/src/assets/styles/components/passport/passportPage.scss
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/assets/styles/components/passport/sections.scss
+++ b/src/assets/styles/components/passport/sections.scss
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/assets/styles/config/variables.scss
+++ b/src/assets/styles/config/variables.scss
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/assets/styles/style.css
+++ b/src/assets/styles/style.css
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/components/general/Alert.vue
+++ b/src/components/general/Alert.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/general/Dialog.vue
+++ b/src/components/general/Dialog.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/general/ErrorComponent.vue
+++ b/src/components/general/ErrorComponent.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/general/FieldBox.vue
+++ b/src/components/general/FieldBox.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/general/Footer.vue
+++ b/src/components/general/Footer.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/general/Header.vue
+++ b/src/components/general/Header.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/general/LoadingComponent.vue
+++ b/src/components/general/LoadingComponent.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/general/NotAuthorizedComponent.vue
+++ b/src/components/general/NotAuthorizedComponent.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/general/NotAvailableComponent.vue
+++ b/src/components/general/NotAvailableComponent.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/general/QrcodeStrem.vue
+++ b/src/components/general/QrcodeStrem.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/general/RecursiveAdditionalData.vue
+++ b/src/components/general/RecursiveAdditionalData.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/general/RecursiveComponent.vue
+++ b/src/components/general/RecursiveComponent.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/general/RecursiveTree.vue
+++ b/src/components/general/RecursiveTree.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/general/SearchInput.vue
+++ b/src/components/general/SearchInput.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/general/SectionHeader.vue
+++ b/src/components/general/SectionHeader.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/general/Spinner.vue
+++ b/src/components/general/Spinner.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/general/StepperItem.vue
+++ b/src/components/general/StepperItem.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/general/TabsComponent.vue
+++ b/src/components/general/TabsComponent.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/general/Tooltip.vue
+++ b/src/components/general/Tooltip.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/passport/AttributeField.vue
+++ b/src/components/passport/AttributeField.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/passport/BarChart.vue
+++ b/src/components/passport/BarChart.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/passport/BatteryCards.vue
+++ b/src/components/passport/BatteryCards.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/passport/DocumentField.vue
+++ b/src/components/passport/DocumentField.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/passport/ElementChart.vue
+++ b/src/components/passport/ElementChart.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/passport/Field.vue
+++ b/src/components/passport/Field.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/passport/GeneralCards.vue
+++ b/src/components/passport/GeneralCards.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/passport/InstructionsField.vue
+++ b/src/components/passport/InstructionsField.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/passport/PassportHeader.vue
+++ b/src/components/passport/PassportHeader.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/passport/Section.vue
+++ b/src/components/passport/Section.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/passport/TransmissionCards.vue
+++ b/src/components/passport/TransmissionCards.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/passport/sections/AdditionalData.vue
+++ b/src/components/passport/sections/AdditionalData.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/passport/sections/BatteryComposition.vue
+++ b/src/components/passport/sections/BatteryComposition.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/passport/sections/CellChemistry.vue
+++ b/src/components/passport/sections/CellChemistry.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/passport/sections/Characteristics.vue
+++ b/src/components/passport/sections/Characteristics.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/passport/sections/Commercial.vue
+++ b/src/components/passport/sections/Commercial.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/passport/sections/Components.vue
+++ b/src/components/passport/sections/Components.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/passport/sections/Documents.vue
+++ b/src/components/passport/sections/Documents.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/passport/sections/ElectrochemicalProperties.vue
+++ b/src/components/passport/sections/ElectrochemicalProperties.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/passport/sections/Exchange.vue
+++ b/src/components/passport/sections/Exchange.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/passport/sections/GeneralInformation.vue
+++ b/src/components/passport/sections/GeneralInformation.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/passport/sections/Handling.vue
+++ b/src/components/passport/sections/Handling.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/passport/sections/Identification.vue
+++ b/src/components/passport/sections/Identification.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/passport/sections/Instructions.vue
+++ b/src/components/passport/sections/Instructions.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/passport/sections/Metadata.vue
+++ b/src/components/passport/sections/Metadata.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/passport/sections/Operation.vue
+++ b/src/components/passport/sections/Operation.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/passport/sections/ProductSpecificParameters.vue
+++ b/src/components/passport/sections/ProductSpecificParameters.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/passport/sections/Serialization.vue
+++ b/src/components/passport/sections/Serialization.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/passport/sections/Sources.vue
+++ b/src/components/passport/sections/Sources.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/passport/sections/SparePartSupplier.vue
+++ b/src/components/passport/sections/SparePartSupplier.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/passport/sections/StateOfBattery.vue
+++ b/src/components/passport/sections/StateOfBattery.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/passport/sections/StateOfHealth.vue
+++ b/src/components/passport/sections/StateOfHealth.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/passport/sections/Sustainability.vue
+++ b/src/components/passport/sections/Sustainability.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/components/passport/sections/Typology.vue
+++ b/src/components/passport/sections/Typology.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/router.js
+++ b/src/router.js
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/services/Authentication.js
+++ b/src/services/Authentication.js
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/services/BackendService.js
+++ b/src/services/BackendService.js
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/services/service.const.js
+++ b/src/services/service.const.js
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/utils/authUtil.js
+++ b/src/utils/authUtil.js
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/utils/configUtil.js
+++ b/src/utils/configUtil.js
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/utils/cryptUtil.js
+++ b/src/utils/cryptUtil.js
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/utils/edcUtil.js
+++ b/src/utils/edcUtil.js
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/utils/jsonUtil.js
+++ b/src/utils/jsonUtil.js
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/utils/numberUtil.js
+++ b/src/utils/numberUtil.js
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/utils/passportUtil.js
+++ b/src/utils/passportUtil.js
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/utils/threadUtil.js
+++ b/src/utils/threadUtil.js
@@ -1,7 +1,7 @@
 /**
- * Catena-X - Digital Product Passport Application
+ * Tractus-X - Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/views/PageNotFound.vue
+++ b/src/views/PageNotFound.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/views/PassportView.vue
+++ b/src/views/PassportView.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -1,7 +1,7 @@
 <!--
-  Catena-X - Digital Product Passport Application
+  Tractus-X - Digital Product Passport Application
 
-  Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+  Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
   Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
 
   See the NOTICE file(s) distributed with this work for additional

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,7 @@
 /**
- * Catena-X -  Digital Product Passport Application
+ * Tractus-X -  Digital Product Passport Application
  *
- * Copyright (c) 2022, 2024 BASF SE, BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
  * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional


### PR DESCRIPTION
# Why we create this PR?
 
As defined in this ticket #231 we need to update our header license to Tractus-X.
Additionally there is also a request to remove BASF from the header licenses and the license.

# What we want to achieve with this PR?
 
We want to update the header licenses.

# What is new?
 
## Updated
- Renamed "Catena-X" to "Tractus-X" in header license prefix
- Removed BASF from the header license and license.
- Fixed incorrect license year findings: 2023 -> 2024 in documentation


## PR Linked to:

Closes #231 
