### PR TITLE
chore(swagger-bugfix): refactor workflow to resolve release version tag issue 

### DIFF
--- a/.github/workflows/publish-swagger-hub.yaml
+++ b/.github/workflows/publish-swagger-hub.yaml
@@ -26,7 +26,7 @@ name: "Publish OpenAPI to Swaggerhub"
 
 on:
   push:
-    branches: [ "main", "develop" ]
+    branches: [ "main", "bugfix/fix-swagger-workflow" ]
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_call:
@@ -61,19 +61,16 @@ jobs:
         run: |
           npm i -g swaggerhub-cli
       
-      - name: Get version tag
+      - name: Extract version tag
         id: version
-        run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
-
-      - name: Set version tag
         run: |
+          echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
           if [ -z ${{ inputs.version }} ]; then
-           
-            export DOWNSTREAM_VERSION=${{ steps.version.outputs.tag }}
+            export DOWNSTREAM_VERSION=${GITHUB_REF#refs/*/}
           else
             export DOWNSTREAM_VERSION=${{ inputs.version }}
           fi
-          echo "[INFO] - DOWNSTREAM_VERSION=$DOWNSTREAM_VERSION" >> "$GITHUB_ENV"
+          echo "DOWNSTREAM_VERSION=$DOWNSTREAM_VERSION" >> "$GITHUB_ENV"
 
       - name: Create and Download API specs
         shell: bash
@@ -93,19 +90,7 @@ jobs:
           docker rm test-container
               
       # create API, will fail if exists
-      - name: Create API
+      - name: Create  and publish API Specs to SwaggerHub
         continue-on-error: true
         run: |
-          swaggerhub api:create ${{ env.SWAGGERHUB_USER }}/digital-product-pass/${{ env.DOWNSTREAM_VERSION }} -f ./dpp-backend/digitalproductpass/tractusx-dpp-api.yaml --visibility=public --published=unpublish
-
-      # Post the API to SwaggerHub as "unpublished", because published APIs cannot be overwritten
-      - name: Publish API Specs to SwaggerHub
-        run: |
-          if [[ ${{ env.DOWNSTREAM_VERSION }} != *-SNAPSHOT ]]; then
-            echo "[INFO] - no snapshot, will set the API to 'published'";
-            swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/digital-product-pass/${{ env.DOWNSTREAM_VERSION }} -f ./dpp-backend/digitalproductpass/tractusx-dpp-api.yaml --visibility=public --published=publish
-            swaggerhub api:setdefault ${{ env.SWAGGERHUB_USER }}/digital-product-pass/${{ env.DOWNSTREAM_VERSION }}
-          else
-            echo "[INFO] - snapshot, will set the API to 'unpublished'";
-            swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/digital-product-pass/${{ env.DOWNSTREAM_VERSION }} -f ./dpp-backend/digitalproductpass/tractusx-dpp-api.yaml --visibility=public --published=unpublish
-          fi
+          swaggerhub api:setdefault ${{ env.SWAGGERHUB_USER }}/digital-product-pass/2.2.0

--- a/.github/workflows/publish-swagger-hub.yaml
+++ b/.github/workflows/publish-swagger-hub.yaml
@@ -26,7 +26,6 @@ name: "Publish OpenAPI to Swaggerhub"
 
 on:
   push:
-    branches: [ "main", "bugfix/fix-swagger-workflow" ]
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_call:
@@ -93,4 +92,5 @@ jobs:
       - name: Create  and publish API Specs to SwaggerHub
         continue-on-error: true
         run: |
-          swaggerhub api:setdefault ${{ env.SWAGGERHUB_USER }}/digital-product-pass/2.2.0
+          swaggerhub api:create ${{ env.SWAGGERHUB_USER }}/digital-product-pass/${{ env.DOWNSTREAM_VERSION }} -f ./dpp-backend/digitalproductpass/tractusx-dpp-api.yaml --visibility=public --published=publish
+          swaggerhub api:setdefault ${{ env.SWAGGERHUB_USER }}/digital-product-pass/${{ env.DOWNSTREAM_VERSION }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
 ## [Unreleased]
 
 ### Added
@@ -43,12 +42,32 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 - Updated documentation references where required
 - Updated infrastructure guide
 - Updated testdata script to allow EDC constrained policy for the registry
+- Refactored the swagger workflow
 
 ### Deleted
 - Deleted unused files/directories/docs/images
     - Removed environment-specific values files from helm charts
     - Removed MOCKed json payloads
     - Removed docker directory
+- Deleted veracode-pipeline workflow (replaced by CodeQL and dependabot)
+
+### Issues Fixed
+- Fixed tagging issue in swagger workflow
+- Fixed table formatting in main `README.md`
+
+### Dependencies Fixed by Dependabot
+* chore(deps): bump actions/upload-artifact from 3 to 4 by @dependabot in https://github.com/eclipse-tractusx/digital-product-pass/pull/214
+* chore(deps): bump helm/chart-testing-action from 2.3.1 to 2.6.1 by @dependabot in https://github.com/eclipse-tractusx/digital-product-pass/pull/216
+* chore(deps): bump actions/setup-python from 4 to 5 by @dependabot in https://github.com/eclipse-tractusx/digital-product-pass/pull/220
+* chore(deps): bump veracode/veracode-uploadandscan-action from 0.2.1 to 0.2.6 by @dependabot in https://github.com/eclipse-tractusx/digital-product-pass/pull/218
+* chore(deps): bump actions/checkout from 3 to 4 by @dependabot in https://github.com/eclipse-tractusx/digital-product-pass/pull/284
+* chore(deps): bump docker/build-push-action from 3 to 5 by @dependabot in https://github.com/eclipse-tractusx/digital-product-pass/pull/283
+* chore(deps): bump container-tools/kind-action from 1 to 2 by @dependabot in https://github.com/eclipse-tractusx/digital-product-pass/pull/285
+* chore(deps): bump github/codeql-action from 2 to 3 by @dependabot in https://github.com/eclipse-tractusx/digital-product-pass/pull/281
+* chore(deps): bump follow-redirects from 1.15.4 to 1.15.6 by @dependabot in https://github.com/eclipse-tractusx/digital-product-pass/pull/258
+* chore(deps): bump azure/setup-helm from 3 to 4 by @dependabot in https://github.com/eclipse-tractusx/digital-product-pass/pull/292
+* chore(deps): bump helm/chart-releaser-action from 1.4.1 to 1.6.0 by @dependabot in https://github.com/eclipse-tractusx/digital-product-pass/pull/291
+* chore(deps): bump actions/setup-java from 3 to 4 by @dependabot in https://github.com/eclipse-tractusx/digital-product-pass/pull/290
 
 
 ## [released]


### PR DESCRIPTION
# Why we create this PR?
 
## Problem Statement
The swagger workflow had a bug that it didn't redirect to the latest release tag e.g., `2.2.0` by default once a new released is published and swagger is accessible from the link https://app.swaggerhub.com/apis/eclipse-tractusx-bot/digital-product-pass

This PR contains the following changes:
- Resolved the release version tagging issue.
- Refactored the workflow
 
# What we want to achieve with this PR?
 
## Expected Behavior
To trigger the workflow and publish OpenAPI specs through central swaggerhub https://app.swaggerhub.com/apis/eclipse-tractusx-bot/digital-product-pass once a new release is published. The API specs must access the new published version of  release tag by default.


# What is new?
 
## Updated
- Refactored the swagger worflow


## Fixed Issues
- Fixed tagging issue in the swagger worflow 

## Linked Issue(s):

#279 
