### PR TITLE
chore(release): updated release version to 3.0.0 from 3.0.0-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 
 
 ## [released]
-## [v3.0.0-rc1] - 13-05-2024
+## [v3.0.0] - 13-05-2024
 ### Added
 - Added security assessment report in /docs for the threat modeling
 - Added SingleApiRequest class for the requested data for the single API.

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ In particular, the appliction is used to access the battery passport data provid
 
 ### Software Version
 #### Helm Chart Version
-<pre id="helm-version"><a href="https://github.com/eclipse-tractusx/digital-product-pass/releases/tag/digital-product-pass-3.0.0-rc1">3.0.0-rc1</a></pre>
+<pre id="helm-version"><a href="https://github.com/eclipse-tractusx/digital-product-pass/releases/tag/digital-product-pass-3.0.0">3.0.0</a></pre>
 #### Application Version
-<pre id="app-version"><a href="https://github.com/eclipse-tractusx/digital-product-pass/releases/tag/v3.0.0-rc1">v3.0.0-rc1</a></pre>
+<pre id="app-version"><a href="https://github.com/eclipse-tractusx/digital-product-pass/releases/tag/v3.0.0">v3.0.0</a></pre>
 
 
 

--- a/charts/digital-product-pass/Chart.yaml
+++ b/charts/digital-product-pass/Chart.yaml
@@ -42,10 +42,10 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 3.0.0-rc1
+version: 3.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.0.0-rc1"
+appVersion: "3.0.0"

--- a/charts/digital-product-pass/README.md
+++ b/charts/digital-product-pass/README.md
@@ -1,6 +1,6 @@
 # digital-product-pass
 
-![Version: 3.0.0-rc1](https://img.shields.io/badge/Version-3.0.0--rc1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0-rc1](https://img.shields.io/badge/AppVersion-3.0.0--rc1-informational?style=flat-square)
+![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
 
 A Helm chart for Tractus-X Digital Product Pass Kubernetes
 

--- a/charts/digital-product-pass/values.yaml
+++ b/charts/digital-product-pass/values.yaml
@@ -201,7 +201,7 @@ backend:
                   rightOperand: "active"
                 - leftOperand: "cx-policy:FrameworkAgreement"
                   operator: "odrl:eq"
-                  rightOperand: "circulareconomy:1.0"
+                  rightOperand: "CircularEconomy:1.0"
                 - leftOperand: "cx-policy:UsagePurpose"
                   operator: "odrl:eq"
                   rightOperand: "cx.circular.dpp:1"

--- a/docs/RELEASE_USER.md
+++ b/docs/RELEASE_USER.md
@@ -26,7 +26,7 @@
 User friendly relase notes without especific technical details.
 
 
-**May 13 2024 (Version 3.0.0-rc1)**
+**May 13 2024 (Version 3.0.0)**
 *13.05.2024*
 
 ### Added

--- a/dpp-backend/charts/digital-product-pass-backend/Chart.yaml
+++ b/dpp-backend/charts/digital-product-pass-backend/Chart.yaml
@@ -42,10 +42,10 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 3.0.0-rc1
+version: 3.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.0.0-rc1"
+appVersion: "3.0.0"

--- a/dpp-backend/charts/digital-product-pass-backend/README.md
+++ b/dpp-backend/charts/digital-product-pass-backend/README.md
@@ -1,6 +1,6 @@
 # digital-product-pass-backend
 
-![Version: 3.0.0-rc1](https://img.shields.io/badge/Version-3.0.0--rc1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0-rc1](https://img.shields.io/badge/AppVersion-3.0.0--rc1-informational?style=flat-square)
+![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
 
 A Helm chart for Tractus-X Digital Product Pass Backend Kubernetes
 

--- a/dpp-backend/digitalproductpass/src/main/resources/application.yml
+++ b/dpp-backend/digitalproductpass/src/main/resources/application.yml
@@ -164,7 +164,7 @@ configuration:
                   rightOperand: "active"
                 - leftOperand: "cx-policy:FrameworkAgreement"
                   operator: "odrl:eq"
-                  rightOperand: "circulareconomy:1.0"
+                  rightOperand: "CircularEconomy:1.0"
                 - leftOperand: "cx-policy:UsagePurpose"
                   operator: "odrl:eq"
                   rightOperand: "cx.circular.dpp:1"

--- a/dpp-frontend/package-lock.json
+++ b/dpp-frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "digital-product-pass-frontend",
-  "version": "3.0.0-rc1",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "digital-product-pass-frontend",
-      "version": "3.0.0-rc1",
+      "version": "3.0.0",
       "dependencies": {
         "@mdi/font": "5.9.55",
         "@popperjs/core": "^2.11.2",

--- a/dpp-frontend/package.json
+++ b/dpp-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digital-product-pass-frontend",
-  "version": "3.0.0-rc1",
+  "version": "3.0.0",
   "private": true,
   "scripts": {
     "serve": "vite --host localhost",

--- a/dpp-verification/README.md
+++ b/dpp-verification/README.md
@@ -27,21 +27,21 @@ SPDX-License-Identifier: Apache-2.0
   <img alt="DPP Verificaion Logo" src="./resources/verification-logo.png" width="350" height="350">
   <br><br>
   <img alt="Version:  v1.0" src="https://img.shields.io/badge/Version-v1.0-blue?style=for-the-badge">
-  <img alt="STATUS: IN PROGRESS" src="https://img.shields.io/badge/Status-In%20Progress-8A2BE2?style=for-the-badge">
-  <h3> Catena-X Data Verification Framework </h3>
+  <img alt="STATUS: RELEASED" src="https://img.shields.io/badge/Status-Released-8A2BE2?style=for-the-badge">
+  <h3> A Catena-X Data Verification Framework </h3>
   <h1> Digital Product Pass Verification Add-on </h1>
   
 </div>
 
-> [!CAUTION]
-> This documentation is still in progress... Not all the content is yet available. It is being migrated and published here whenever it is ready. It will be finished and added to main in the R24.05
+> [!IMPORTANT]
+> This is the first version of the Digital Product Pass Verification Framework, more details will be added in the next release R24.08 regarding the implementation. And a first PoC will be implemented in the application for consumer verification. More information can be found in the issue: [eclipse-tractusx/sig-release#655](https://github.com/eclipse-tractusx/sig-release/issues/655)
 
 # Metadata
 
 |                      | Date              | Authors & Reviewers                                   |
 | -------------------- | ----------------- | ----------------------------------------------------- |
 | **Created**          | December 29, 2023 | [Mathias Brunkow Moser](https://github.com/matbmoser) |
-| **Lastest Revision** | May 13, 2024      | [Mathias Brunkow Moser](https://github.com/matbmoser) |
+| **Lastest Revision** | May 16, 2024      | [Mathias Brunkow Moser](https://github.com/matbmoser) |
 
 ## Authors
 
@@ -192,7 +192,7 @@ When talking about the certification and verification of data we can find severa
 # Previous Investigation
 <!-- TODO: Add previous investigation here -->
 > [!WARNING]
-> Previous investigation is still not available here!
+> Previous investigation is still not available in this version.
 
 
 # Processes Terminology
@@ -808,7 +808,7 @@ Here we have an example of the generated CSC from the [previous CDC Aspect](#cer
 # Technical Integration Design
 <!-- TODO: Add previous TID here -->
 > [!WARNING]
-> The complete technical integration design is still not available here!
+> The complete technical integration design is still not available here! More details comming soon...
 
 ## Interfaces
 


### PR DESCRIPTION
# Why we create this PR?

To publish the digital product pass application used in the E2E tests. 

# What we want to achieve with this PR?
 
Publish the application and update the charts.
 
# What is new?
 
## Updated
- Updated charts
- Set dpp verification documentation to released
- Updated default constraint from framework agreement to CircularEconomy from circulareconomy

