### PR TITLE
Feature/irs: Make IRS compatible to the dpp-backend

### DIFF
--- a/charts/digital-product-pass/templates/deployment-backend.yaml
+++ b/charts/digital-product-pass/templates/deployment-backend.yaml
@@ -88,7 +88,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: irsApiKey
-                  name: { { .Release.Name } }-backend-auth
+                  name: {{ .Release.Name }}-backend-auth
           volumeMounts:
             {{- toYaml .Values.backend.volumeMounts | nindent 12 }}
           ports:

--- a/charts/digital-product-pass/templates/deployment-backend.yaml
+++ b/charts/digital-product-pass/templates/deployment-backend.yaml
@@ -84,6 +84,11 @@ spec:
                 secretKeyRef:
                   key: xApiKey
                   name: {{ .Release.Name }}-backend-auth
+            - name: "irs.apiKey"
+              valueFrom:
+                secretKeyRef:
+                  key: irsApiKey
+                  name: { { .Release.Name } }-backend-auth
           volumeMounts:
             {{- toYaml .Values.backend.volumeMounts | nindent 12 }}
           ports:

--- a/charts/digital-product-pass/templates/deployment-frontend.yaml
+++ b/charts/digital-product-pass/templates/deployment-frontend.yaml
@@ -104,10 +104,10 @@ spec:
             - name: "API_MAX_RETRIES"
               value: "{{ .Values.frontend.api.max_retries }}"
 
-            - name: "API_IRS_DELAY"
+            - name: "IRS_DELAY"
               value: "{{ .Values.frontend.irs.requestDelay }}"
 
-            - name: "API_IRS_MAX_WAITING_TIME"
+            - name: "IRS_MAX_WAITING_TIME"
               value: "{{ .Values.frontend.irs.maxWaitingTime }}"
 
             - name: "API_DELAY"

--- a/charts/digital-product-pass/templates/deployment-frontend.yaml
+++ b/charts/digital-product-pass/templates/deployment-frontend.yaml
@@ -104,10 +104,10 @@ spec:
             - name: "API_MAX_RETRIES"
               value: "{{ .Values.frontend.api.max_retries }}"
 
-            - name: "IRS_DELAY"
+            - name: "API_IRS_DELAY"
               value: "{{ .Values.frontend.irs.requestDelay }}"
 
-            - name: "IRS_MAX_WAITING_TIME"
+            - name: "API_IRS_MAX_WAITING_TIME"
               value: "{{ .Values.frontend.irs.maxWaitingTime }}"
 
             - name: "API_DELAY"

--- a/charts/digital-product-pass/templates/secret-backend.yaml
+++ b/charts/digital-product-pass/templates/secret-backend.yaml
@@ -35,7 +35,7 @@ stringData:
   clientId: {{ .Values.oauth.techUser.clientId }}
   clientSecret: {{ .Values.oauth.techUser.clientSecret }}
   xApiKey: {{ .Values.oauth.apiKey.secret }}
-  
+  irsApiKey: {{ .Values.backend.irs.apiKey }}
 ---
 
 apiVersion: v1

--- a/charts/digital-product-pass/values-int.yaml
+++ b/charts/digital-product-pass/values-int.yaml
@@ -57,6 +57,7 @@ backend:
   irs:
     enabled: true
     hostname: "materialpass-irs.int.demo.catena-x.net"
+    apiKey: "<path:material-pass/data/int/irs/apiKey#apiKeyRegular>"
 
   process:
     encryptionKey: "<path:material-pass/data/int/backend/#signKey>"

--- a/charts/digital-product-pass/values.yaml
+++ b/charts/digital-product-pass/values.yaml
@@ -172,6 +172,7 @@ backend:
   irs:
     enabled: false
     hostname: ""
+    apiKey: "<Add API Key>"
 
   # -- digital twin registry configuration
   process:
@@ -349,7 +350,6 @@ frontend:
     requestDelay: 30000
     # -- maximum waiting time to get the irs job status
     maxWaitingTime: 30
-    apiKey: "<Add API Key>"
 
 # -- oauth configuration
 oauth:

--- a/charts/digital-product-pass/values.yaml
+++ b/charts/digital-product-pass/values.yaml
@@ -349,6 +349,7 @@ frontend:
     requestDelay: 30000
     # -- maximum waiting time to get the irs job status
     maxWaitingTime: 30
+    apiKey: "<Add API Key>"
 
 # -- oauth configuration
 oauth:

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/irs/IrsShell.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/irs/IrsShell.java
@@ -1,0 +1,82 @@
+/*********************************************************************************
+ *
+ * Tractus-X - Digital Product Passport Application
+ *
+ * Copyright (c) 2022, 2024 BMW AG, Henkel AG & Co. KGaA
+ * Copyright (c) 2023, 2024 CGI Deutschland B.V. & Co. KG
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ *
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.digitalproductpass.models.irs;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.eclipse.tractusx.digitalproductpass.models.dtregistry.DigitalTwin;
+
+import java.util.ArrayList;
+
+/**
+ * This class consists exclusively to define attributes related to the Job Response coming from the IRS.
+ **/
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class IrsShell {
+
+    /**
+     * ATTRIBUTES
+     **/
+    @JsonProperty("contractAgreementId")
+    public String contractAgreementId;
+    @JsonProperty("payload")
+    public DigitalTwin payload;
+
+
+    /**
+     * CONSTRUCTORS
+     **/
+    public IrsShell() {
+    }
+
+    public IrsShell(String contractAgreementId, DigitalTwin payload) {
+        this.contractAgreementId = contractAgreementId;
+        this.payload = payload;
+    }
+
+    /**
+     * GETTERS AND SETTERS
+     **/
+    public String getContractAgreementId() {
+        return contractAgreementId;
+    }
+
+    public void setContractAgreementId(String contractAgreementId) {
+        this.contractAgreementId = contractAgreementId;
+    }
+
+    public DigitalTwin getPayload() {
+        return payload;
+    }
+
+    public void setPayload(DigitalTwin payload) {
+        this.payload = payload;
+    }
+}

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/irs/JobResponse.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/models/irs/JobResponse.java
@@ -30,7 +30,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
-import org.eclipse.tractusx.digitalproductpass.models.dtregistry.DigitalTwin;
 
 import java.util.ArrayList;
 
@@ -47,7 +46,7 @@ public class JobResponse {
     @JsonProperty("relationships")
     public ArrayList<Relationship> relationships;
     @JsonProperty("shells")
-    public ArrayList<DigitalTwin> shells;
+    public ArrayList<IrsShell> shells;
     @JsonProperty("tombstones")
     public Object tombstones;
     @JsonProperty("submodels")
@@ -56,7 +55,7 @@ public class JobResponse {
     public ArrayList<String> bpns;
 
     /** CONSTRUCTOR(S) **/
-    public JobResponse(Job job, ArrayList<Relationship> relationships, ArrayList<DigitalTwin> shells, Object tombstones, ArrayList<JsonNode> submodels, ArrayList<String> bpns) {
+    public JobResponse(Job job, ArrayList<Relationship> relationships, ArrayList<IrsShell> shells, Object tombstones, ArrayList<JsonNode> submodels, ArrayList<String> bpns) {
         this.job = job;
         this.relationships = relationships;
         this.shells = shells;
@@ -85,11 +84,11 @@ public class JobResponse {
         this.relationships = relationships;
     }
 
-    public ArrayList<DigitalTwin> getShells() {
+    public ArrayList<IrsShell> getShells() {
         return shells;
     }
 
-    public void setShells(ArrayList<DigitalTwin> shells) {
+    public void setShells(ArrayList<IrsShell> shells) {
         this.shells = shells;
     }
 

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/IrsService.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/IrsService.java
@@ -65,6 +65,7 @@ public class IrsService extends BaseService {
     String irsEndpoint;
     String irsJobPath;
     String callbackUrl;
+    String apiKey;
     AuthenticationService authService;
     IrsConfig irsConfig;
     ProcessManager processManager;
@@ -96,6 +97,7 @@ public class IrsService extends BaseService {
         this.irsEndpoint = this.irsConfig.getEndpoint();
         this.irsJobPath = this.irsConfig.getPaths().getJob();
         this.callbackUrl = this.irsConfig.getCallbackUrl();
+        this.apiKey = (String) this.vaultService.getLocalSecret("irs.apiKey");
     }
     /**
      * Creates a List of missing variables needed to proceed with the request.
@@ -115,6 +117,9 @@ public class IrsService extends BaseService {
         }
         if (this.callbackUrl.isEmpty()) {
             missingVariables.add("irs.callbackUrl");
+        }
+        if (this.apiKey.isEmpty()) {
+            missingVariables.add("irs.apiKey");
         }
         return missingVariables;
     }
@@ -183,7 +188,7 @@ public class IrsService extends BaseService {
                     callbackUrl
             );
             body.setKey(globalAssetId, bpn);
-            HttpHeaders headers = httpUtil.getHeadersWithApiKey((String) this.vaultService.getLocalSecret("irs.apiKey"));
+            HttpHeaders headers = httpUtil.getHeadersWithApiKey(this.apiKey);
             headers.add("Content-Type", "application/json");
 
             ResponseEntity<?> response = httpUtil.doPost(url, JsonNode.class, headers, httpUtil.getParams(), body, false, false);
@@ -283,7 +288,7 @@ public class IrsService extends BaseService {
         try {
             String url = this.irsEndpoint + "/" + this.irsJobPath + "/" + jobId;
             Map<String, Object> params = httpUtil.getParams();
-            HttpHeaders headers = httpUtil.getHeadersWithToken(this.authService.getToken().getAccessToken());
+            HttpHeaders headers = httpUtil.getHeadersWithApiKey(this.apiKey);
             ResponseEntity<?> response = httpUtil.doGet(url, String.class, headers, params, true, false);
             String responseBody = (String) response.getBody();
             return (JobResponse) jsonUtil.bindJsonNode(jsonUtil.toJsonNode(responseBody), JobResponse.class);

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/IrsService.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/IrsService.java
@@ -168,7 +168,7 @@ public class IrsService extends BaseService {
     public Map<String, String> startJob(String processId, String globalAssetId,  String searchId, String bpn) {
         try {
             this.checkEmptyVariables();
-            String url = this.irsEndpoint + "/" + this.irsJobPath;
+            String url = this.irsEndpoint + this.irsJobPath;
             // Build the Job request for the IRS
 
             String backendUrl = this.callbackUrl +  "/" + processId + "/" + searchId; // Add process id and search id

--- a/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/IrsService.java
+++ b/dpp-backend/digitalproductpass/src/main/java/org/eclipse/tractusx/digitalproductpass/services/IrsService.java
@@ -183,7 +183,7 @@ public class IrsService extends BaseService {
                     callbackUrl
             );
             body.setKey(globalAssetId, bpn);
-            HttpHeaders headers = httpUtil.getHeadersWithToken(this.authService.getToken().getAccessToken());
+            HttpHeaders headers = httpUtil.getHeadersWithApiKey((String) this.vaultService.getLocalSecret("irs.apiKey"));
             headers.add("Content-Type", "application/json");
 
             ResponseEntity<?> response = httpUtil.doPost(url, JsonNode.class, headers, httpUtil.getParams(), body, false, false);

--- a/dpp-backend/digitalproductpass/src/main/java/utils/HttpUtil.java
+++ b/dpp-backend/digitalproductpass/src/main/java/utils/HttpUtil.java
@@ -1060,6 +1060,11 @@ public class HttpUtil {
         headers.add("Authorization", "Bearer " + accessToken);
         return headers;
     }
+    public  HttpHeaders getHeadersWithApiKey(String apiKey) {
+        HttpHeaders headers =  new HttpHeaders();
+        headers.add("X-Api-Key", apiKey);
+        return headers;
+    }
     public  Map<String, Object> getParams() {
         return new HashMap<String, Object>();
     }

--- a/dpp-backend/digitalproductpass/src/main/resources/application.yml
+++ b/dpp-backend/digitalproductpass/src/main/resources/application.yml
@@ -185,6 +185,7 @@ configuration:
       - "edc.apiKey"
       - "edc.participantId"
       - "oauth.apiKey"
+      - "irs.apiKey"
 
 server:
   error:

--- a/dpp-backend/digitalproductpass/src/test/java/services/IrsServiceTest.java
+++ b/dpp-backend/digitalproductpass/src/test/java/services/IrsServiceTest.java
@@ -112,7 +112,7 @@ class IrsServiceTest {
         when(vaultService.getLocalSecret("client.id")).thenReturn(mockClientId);
         when(vaultService.getLocalSecret("client.secret")).thenReturn(mockClientTestReturn);
 
-        when(vaultService.getLocalSecret("edc.apiKey")).thenReturn(mockApiKey);
+        when(vaultService.getLocalSecret("irs.apiKey")).thenReturn(mockApiKey);
         when(vaultService.getLocalSecret("edc.participantId")).thenReturn(mockBpn);
 
 

--- a/dpp-backend/digitalproductpass/src/test/resources/application-test.yml
+++ b/dpp-backend/digitalproductpass/src/test/resources/application-test.yml
@@ -184,6 +184,7 @@ configuration:
       - "edc.apiKey"
       - "edc.participantId"
       - "oauth.apiKey"
+      - "irs.apiKey"
 
 server:
   error:

--- a/dpp-backend/digitalproductpass/src/test/resources/dpp/irs/TestJobResponse.json
+++ b/dpp-backend/digitalproductpass/src/test/resources/dpp/irs/TestJobResponse.json
@@ -55,235 +55,231 @@
   ],
   "shells": [
     {
-      "administration": null,
-      "description": [
-        {
-          "language": "en",
-          "text": "Battery Digital Twin"
-        }
-      ],
-      "globalAssetId": "urn:uuid:efcb5f8d-f31c-4b1f-b090-9c878054554d",
-      "idShort": "Battery_BAT-XYZ789",
-      "id": "urn:uuid:3d050cd8-cdc7-4d65-9f37-70a65d5f53f5",
-      "specificAssetIds": [
-        {
-          "name": "partInstanceId",
-          "subjectId": null,
-          "value": "BAT-XYZ789",
-          "semanticId": null
-        },
-        {
-          "name": "manufacturerPartId",
-          "subjectId": null,
-          "value": "XYZ78901",
-          "semanticId": null
-        }
-      ],
-      "submodelDescriptors": [
-        {
-          "administration": null,
-          "description": [],
-          "idShort": "SerialPart",
-          "id": "urn:uuid:1ea64f49-8b2b-4cd2-818e-cf9d452c6fea",
-          "semanticId": {
-            "keys": [
-              {
-                "value": "urn:bamm:io.catenax.serial_part:1.0.1#SerialPart",
-                "type": "Submodel"
-              }
-            ],
-            "type": "ExternalReference"
+      "contractAgreementId": "67577082-6aba-484c-8cdf-c6613b565c17",
+      "payload": {
+        "administration": null,
+        "description": [
+          {
+            "language": "en",
+            "text": "Battery Digital Twin"
+          }
+        ],
+        "globalAssetId": "urn:uuid:efcb5f8d-f31c-4b1f-b090-9c878054554d",
+        "idShort": "Battery_BAT-XYZ789",
+        "id": "urn:uuid:3d050cd8-cdc7-4d65-9f37-70a65d5f53f5",
+        "specificAssetIds": [
+          {
+            "name": "partInstanceId",
+            "subjectId": null,
+            "value": "BAT-XYZ789",
+            "semanticId": null
           },
-          "endpoints": [
-            {
-              "protocolInformation": {
-                "href": "https://materialpass.int.demo.catena-x.net/BPNL000000000000/api/public/data/urn:uuid:1ea64f49-8b2b-4cd2-818e-cf9d452c6fea"
-              ,
-                "endpointProtocol": "HTTP",
-                "endpointProtocolVersion": [
-                  "1.1"
-                ],
-                "subprotocol": "DSP",
-                "subprotocolBody": "id=urn:uuid:3e4a5957-f226-478a-ab18-79ced49d6195;dspEndpoint=https://materialpass.int.demo.catena-x.net/BPNL000000000000"
-              ,
-                "subprotocolBodyEncoding": "plain"
-              },
-              "interface": "SUBMODEL-3.0"
-            }
-          ]
-        }
-      ]
+          {
+            "name": "manufacturerPartId",
+            "subjectId": null,
+            "value": "XYZ78901",
+            "semanticId": null
+          }
+        ],
+        "submodelDescriptors": [
+          {
+            "administration": null,
+            "description": [],
+            "idShort": "SerialPart",
+            "id": "urn:uuid:1ea64f49-8b2b-4cd2-818e-cf9d452c6fea",
+            "semanticId": {
+              "keys": [
+                {
+                  "value": "urn:bamm:io.catenax.serial_part:1.0.1#SerialPart",
+                  "type": "Submodel"
+                }
+              ],
+              "type": "ExternalReference"
+            },
+            "endpoints": [
+              {
+                "protocolInformation": {
+                  "href": "https://materialpass.int.demo.catena-x.net/BPNL000000000000/api/public/data/urn:uuid:1ea64f49-8b2b-4cd2-818e-cf9d452c6fea",
+                  "endpointProtocol": "HTTP",
+                  "endpointProtocolVersion": [
+                    "1.1"
+                  ],
+                  "subprotocol": "DSP",
+                  "subprotocolBody": "id=urn:uuid:3e4a5957-f226-478a-ab18-79ced49d6195;dspEndpoint=https://materialpass.int.demo.catena-x.net/BPNL000000000000",
+                  "subprotocolBodyEncoding": "plain"
+                },
+                "interface": "SUBMODEL-3.0"
+              }
+            ]
+          }
+        ]
+      }
     },
     {
-      "administration": null,
-      "description": [
-        {
-          "language": "en",
-          "text": "Battery Module Digital Twin"
-        }
-      ],
-      "globalAssetId": "urn:uuid:d8ec6acc-1ad7-47b4-bc7e-612122d9d552",
-      "idShort": "BatteryModule_EVMODULE-TRJ712",
-      "id": "urn:uuid:ace301f6-92c5-4623-a022-c2a30dfee0e2",
-      "specificAssetIds": [
-        {
-          "name": "partInstanceId",
-          "subjectId": null,
-          "value": "EVMODULE-TRJ712",
-          "semanticId": null
-        },
-        {
-          "name": "manufacturerPartId",
-          "subjectId": null,
-          "value": "XYZ78901",
-          "semanticId": null
-        }
-      ],
-      "submodelDescriptors": [
-        {
-          "administration": null,
-          "description": [
-            {
-              "language": "en",
-              "text": "Digital Product Passport Submodel"
-            }
-          ],
-          "idShort": "singleLevelBomAsBuilt",
-          "id": "urn:uuid:c216bece-b17f-4679-8b62-ec25810ca1c4",
-          "semanticId": {
-            "keys": [
+      "contractAgreementId": "04f60414-4fac-4a05-9c0f-5ab11cb6e16c",
+      "payload": {
+        "administration": null,
+        "description": [
+          {
+            "language": "en",
+            "text": "Battery Module Digital Twin"
+          }
+        ],
+        "globalAssetId": "urn:uuid:d8ec6acc-1ad7-47b4-bc7e-612122d9d552",
+        "idShort": "BatteryModule_EVMODULE-TRJ712",
+        "id": "urn:uuid:ace301f6-92c5-4623-a022-c2a30dfee0e2",
+        "specificAssetIds": [
+          {
+            "name": "partInstanceId",
+            "subjectId": null,
+            "value": "EVMODULE-TRJ712",
+            "semanticId": null
+          },
+          {
+            "name": "manufacturerPartId",
+            "subjectId": null,
+            "value": "XYZ78901",
+            "semanticId": null
+          }
+        ],
+        "submodelDescriptors": [
+          {
+            "administration": null,
+            "description": [
               {
-                "value": "urn:bamm:io.catenax.single_level_bom_as_built:1.0.0#SingleLevelBomAsBuilt",
-                "type": "Submodel"
+                "language": "en",
+                "text": "Digital Product Passport Submodel"
               }
             ],
-            "type": "ExternalReference"
-          },
-          "endpoints": [
-            {
-              "protocolInformation": {
-                "href": "https://materialpass.int.demo.catena-x.net/BPNL000000000000/api/public/data/urn:uuid:c216bece-b17f-4679-8b62-ec25810ca1c4"
-              ,
-                "endpointProtocol": "HTTP",
-                "endpointProtocolVersion": [
-                  "1.1"
-                ],
-                "subprotocol": "DSP",
-                "subprotocolBody": "id=urn:uuid:3e4a5957-f226-478a-ab18-79ced49d6195;dspEndpoint=https://materialpass.int.demo.catena-x.net/BPNL000000000000/"
-              ,
-                "subprotocolBodyEncoding": "plain"
-              },
-              "interface": "SUBMODEL-3.0"
-            }
-          ]
-        },
-        {
-          "administration": null,
-          "description": [],
-          "idShort": "SerialPart",
-          "id": "urn:uuid:906e5e5e-f9c1-427c-b923-e5f863bc40df",
-          "semanticId": {
-            "keys": [
+            "idShort": "singleLevelBomAsBuilt",
+            "id": "urn:uuid:c216bece-b17f-4679-8b62-ec25810ca1c4",
+            "semanticId": {
+              "keys": [
+                {
+                  "value": "urn:bamm:io.catenax.single_level_bom_as_built:1.0.0#SingleLevelBomAsBuilt",
+                  "type": "Submodel"
+                }
+              ],
+              "type": "ExternalReference"
+            },
+            "endpoints": [
               {
-                "value": "urn:bamm:io.catenax.serial_part:1.0.1#SerialPart",
-                "type": "Submodel"
+                "protocolInformation": {
+                  "href": "https://materialpass.int.demo.catena-x.net/BPNL000000000000/api/public/data/urn:uuid:c216bece-b17f-4679-8b62-ec25810ca1c4",
+                  "endpointProtocol": "HTTP",
+                  "endpointProtocolVersion": [
+                    "1.1"
+                  ],
+                  "subprotocol": "DSP",
+                  "subprotocolBody": "id=urn:uuid:3e4a5957-f226-478a-ab18-79ced49d6195;dspEndpoint=https://materialpass.int.demo.catena-x.net/BPNL000000000000/",
+                  "subprotocolBodyEncoding": "plain"
+                },
+                "interface": "SUBMODEL-3.0"
+              }
+            ]
+          },
+          {
+            "administration": null,
+            "description": [],
+            "idShort": "SerialPart",
+            "id": "urn:uuid:906e5e5e-f9c1-427c-b923-e5f863bc40df",
+            "semanticId": {
+              "keys": [
+                {
+                  "value": "urn:bamm:io.catenax.serial_part:1.0.1#SerialPart",
+                  "type": "Submodel"
+                }
+              ],
+              "type": "ExternalReference"
+            },
+            "endpoints": [
+              {
+                "protocolInformation": {
+                  "href": "https://materialpass.int.demo.catena-x.net/BPNL000000000000/api/public/data/urn:uuid:906e5e5e-f9c1-427c-b923-e5f863bc40df",
+                  "endpointProtocol": "HTTP",
+                  "endpointProtocolVersion": [
+                    "1.1"
+                  ],
+                  "subprotocol": "DSP",
+                  "subprotocolBody": "id=urn:uuid:3e4a5957-f226-478a-ab18-79ced49d6195;dspEndpoint=https://materialpass.int.demo.catena-x.net/BPNL000000000000",
+                  "subprotocolBodyEncoding": "plain"
+                },
+                "interface": "SUBMODEL-3.0"
+              }
+            ]
+          },
+          {
+            "administration": null,
+            "description": [
+              {
+                "language": "en",
+                "text": "Digital Product Passport Submodel"
               }
             ],
-            "type": "ExternalReference"
-          },
-          "endpoints": [
-            {
-              "protocolInformation": {
-                "href": "https://materialpass.int.demo.catena-x.net/BPNL000000000000/api/public/data/urn:uuid:906e5e5e-f9c1-427c-b923-e5f863bc40df"
-              ,
-                "endpointProtocol": "HTTP",
-                "endpointProtocolVersion": [
-                  "1.1"
-                ],
-                "subprotocol": "DSP",
-                "subprotocolBody": "id=urn:uuid:3e4a5957-f226-478a-ab18-79ced49d6195;dspEndpoint=https://materialpass.int.demo.catena-x.net/BPNL000000000000"
-              ,
-                "subprotocolBodyEncoding": "plain"
-              },
-              "interface": "SUBMODEL-3.0"
-            }
-          ]
-        },
-        {
-          "administration": null,
-          "description": [
-            {
-              "language": "en",
-              "text": "Digital Product Passport Submodel"
-            }
-          ],
-          "idShort": "digitalProductPass",
-          "id": "urn:uuid:754b6c6c-d74a-4dd0-a62c-f07959f15332",
-          "semanticId": {
-            "keys": [
+            "idShort": "digitalProductPass",
+            "id": "urn:uuid:754b6c6c-d74a-4dd0-a62c-f07959f15332",
+            "semanticId": {
+              "keys": [
+                {
+                  "value": "urn:bamm:io.catenax.generic.digital_product_passport:1.0.0#DigitalProductPassport",
+                  "type": "Submodel"
+                }
+              ],
+              "type": "ExternalReference"
+            },
+            "endpoints": [
               {
-                "value": "urn:bamm:io.catenax.generic.digital_product_passport:1.0.0#DigitalProductPassport",
-                "type": "Submodel"
+                "protocolInformation": {
+                  "href": "https://materialpass.int.demo.catena-x.net/BPNL000000000000/api/public/data/urn:uuid:754b6c6c-d74a-4dd0-a62c-f07959f15332",
+                  "endpointProtocol": "HTTP",
+                  "endpointProtocolVersion": [
+                    "1.1"
+                  ],
+                  "subprotocol": "DSP",
+                  "subprotocolBody": "id=urn:uuid:3e4a5957-f226-478a-ab18-79ced49d6195;dspEndpoint=https://materialpass.int.demo.catena-x.net/BPNL000000000000/",
+                  "subprotocolBodyEncoding": "plain"
+                },
+                "interface": "SUBMODEL-3.0"
+              }
+            ]
+          },
+          {
+            "administration": null,
+            "description": [
+              {
+                "language": "en",
+                "text": "Digital Product Passport Submodel"
               }
             ],
-            "type": "ExternalReference"
-          },
-          "endpoints": [
-            {
-              "protocolInformation": {
-                "href": "https://materialpass.int.demo.catena-x.net/BPNL000000000000/api/public/data/urn:uuid:754b6c6c-d74a-4dd0-a62c-f07959f15332"
-              ,
-                "endpointProtocol": "HTTP",
-                "endpointProtocolVersion": [
-                  "1.1"
-                ],
-                "subprotocol": "DSP",
-                "subprotocolBody": "id=urn:uuid:3e4a5957-f226-478a-ab18-79ced49d6195;dspEndpoint=https://materialpass.int.demo.catena-x.net/BPNL000000000000/"
-              ,
-                "subprotocolBodyEncoding": "plain"
-              },
-              "interface": "SUBMODEL-3.0"
-            }
-          ]
-        },
-        {
-          "administration": null,
-          "description": [
-            {
-              "language": "en",
-              "text": "Digital Product Passport Submodel"
-            }
-          ],
-          "idShort": "SingleLevelUsageAsBuilt",
-          "id": "urn:uuid:25ea2646-d57f-4b31-97a0-d0d7b3b35d37",
-          "semanticId": {
-            "keys": [
+            "idShort": "SingleLevelUsageAsBuilt",
+            "id": "urn:uuid:25ea2646-d57f-4b31-97a0-d0d7b3b35d37",
+            "semanticId": {
+              "keys": [
+                {
+                  "value": "urn:bamm:io.catenax.single_level_usage_as_built:1.0.1#SingleLevelUsageAsBuilt",
+                  "type": "Submodel"
+                }
+              ],
+              "type": "ExternalReference"
+            },
+            "endpoints": [
               {
-                "value": "urn:bamm:io.catenax.single_level_usage_as_built:1.0.1#SingleLevelUsageAsBuilt",
-                "type": "Submodel"
+                "protocolInformation": {
+                  "href": "https://materialpass.int.demo.catena-x.net/BPNL000000000000/api/public/data/urn:uuid:25ea2646-d57f-4b31-97a0-d0d7b3b35d37",
+                  "endpointProtocol": "HTTP",
+                  "endpointProtocolVersion": [
+                    "1.1"
+                  ],
+                  "subprotocol": "DSP",
+                  "subprotocolBody": "id=urn:uuid:3e4a5957-f226-478a-ab18-79ced49d6195;dspEndpoint=https://materialpass.int.demo.catena-x.net/BPNL000000000000/",
+                  "subprotocolBodyEncoding": "plain"
+                },
+                "interface": "SUBMODEL-3.0"
               }
-            ],
-            "type": "ExternalReference"
-          },
-          "endpoints": [
-            {
-              "protocolInformation": {
-                "href": "https://materialpass.int.demo.catena-x.net/BPNL000000000000/api/public/data/urn:uuid:25ea2646-d57f-4b31-97a0-d0d7b3b35d37"
-              ,
-                "endpointProtocol": "HTTP",
-                "endpointProtocolVersion": [
-                  "1.1"
-                ],
-                "subprotocol": "DSP",
-                "subprotocolBody": "id=urn:uuid:3e4a5957-f226-478a-ab18-79ced49d6195;dspEndpoint=https://materialpass.int.demo.catena-x.net/BPNL000000000000/"
-              ,
-                "subprotocolBodyEncoding": "plain"
-              },
-              "interface": "SUBMODEL-3.0"
-            }
-          ]
-        }
-      ]
+            ]
+          }
+        ]
+      }
     }
   ],
   "tombstones": [],


### PR DESCRIPTION
# Why we create this PR?
 
- Added apiKey to the api request headers in backend and in helm charts
- Added IrsShell class to parse the IRS JobResponse payload
- Update `DigitalTwin` references with `IrsShell` to TreeManager class to retrieve child components
- Update unit tests to IrsService

# What we want to achieve with this PR?

To make IRS drill down to work with the new EDC `0.7.0` 
 
# What is new?

## Updated
- Added apiKey to the api request headers in backend and in helm charts
- Added IrsShell class to parse the IRS JobResponse payload
- Update `DigitalTwin` references with `IrsShell` to TreeManager class to retrieve child components
- Update unit tests to IrsService

## PR Linked to:

PR #327 
Issue #266 
