### PR TITLE
release/v3.1.0/chore(changelog): updated CHANGELOG.md and helm chart version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,49 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 
 ## [Unreleased]
 
+## [released]
+## [v3.1.0] - 19-06-2024
+### Added
+
+- Added a new file `LICENSE_non-code` file in root level with the contents of the CC-BY-4.0 license
+- Added dpp-tutorial to step-by-step guide (readme files) of DPP worksession at the Tractus-X Community Days:
+    - deployment.md
+    - data-provision.md
+    - aspect-model.md
+    - data-consumption.md
+    - digital-twin-provision.md
+    - qr-code.md
+
+
+### Updated
+
+- Updated the contents of "Project Licenses" and "Terms of Use" sections to the `CONTRIBUTING.md` file
+- Updated "Declared Project License" section in `NOTICE.md`.
+- Updated the license header and notices to following readme files:
+  - main README.md
+  - /docs/*
+  - /dpp-backend/*
+  - /dpp-tutorial/*
+  - /deployment/*
+  - /dpp-verification/*
+  - AUTHORS.md
+  - SECURITY.md
+  - INSTALL.md
+  - NOTICE.md
+  - CONTRIBUTING.md
+  - CHANGELOG.md
+- Updated dpp-frontend to support the following new models:
+    - Digital Product Pass `v5.0.0`
+    - Battery Pass `6.0.0`
+    - Transmission Pass `3.0.0`
+- Updated EDC version `v0.7.0`
+- Updated IRS version `v7.1.3`
+
+ ### Issues Fixed
+ - Fixed token refresh for keycloak plugin in frontend
+ - Fixed IRS configuration keys in docker entrypoint script for frotnend
+ - Fixed CORS issue in frontend #274
+
 
 ## [released]
 ## [v3.0.0] - 13-05-2024

--- a/docs/RELEASE_USER.md
+++ b/docs/RELEASE_USER.md
@@ -22,7 +22,27 @@ SPDX-License-Identifier: CC-BY-4.0
 -->
 
 # Release Notes Digital Product Pass Application
-User friendly relase notes without especific technical details.
+User friendly relase notes without specific technical details.
+
+
+
+**June 19 2024 (Version 3.1.0)**
+*19.06.2024*
+
+### Updated
+
+#### Support of new data models:
+
+The frontend component from the Digital Product Pass application  is now adapted to support the following new models:
+- Digital Product Pass `v2.0.0` to `v5.0.0`
+- Battery Pass `v3.0.1` to `6.0.0`
+- Transmission Pass `v1.0.0` to `3.0.0`
+
+This adaption deprecates and removed the retro-compatibility from the old models.
+
+#### Update licensing for the non-code licensed documentation
+
+There was a change from legal documentation. Instead of Apache-2.0 licensing in documentation, it now supports non-code licensing in license headers and NOTICE sections. This is a default license from the Creative Commons Attribution 4.0 International (CC-BY-4.0).
 
 
 **May 13 2024 (Version 3.0.0)**


### PR DESCRIPTION
# Why we create this PR?
 
Updated changelog.md , RELEASE_USER.md and dpp helm chart versions `v3.1.0`.
 
# What is new?
 
### Updated
- Changelog.md
- RELEASE_USER.md
- DPP Helm Chart version

Closes #274 
