### PR TITLE
chore(dtr): update dtr chart version to v0.5.0

### DIFF
--- a/deployment/infrastructure/data-provider/registry/Chart.yaml
+++ b/deployment/infrastructure/data-provider/registry/Chart.yaml
@@ -28,11 +28,11 @@ name: registry
 description: Tractus-X Digital Twin Registry Helm Chart
 
 type: application
-version: 0.5.0
+version: 0.5.2
 
 dependencies:
   - name: digital-twin-registry
     repository: https://eclipse-tractusx.github.io/sldt-digital-twin-registry
     alias: provider-dtr
-    version: 0.5.0
+    version: 0.5.2
     condition: enabled

--- a/deployment/infrastructure/data-provider/registry/Chart.yaml
+++ b/deployment/infrastructure/data-provider/registry/Chart.yaml
@@ -28,11 +28,11 @@ name: registry
 description: Tractus-X Digital Twin Registry Helm Chart
 
 type: application
-version: 0.3.31
+version: 0.5.0
 
 dependencies:
   - name: digital-twin-registry
     repository: https://eclipse-tractusx.github.io/sldt-digital-twin-registry
     alias: provider-dtr
-    version: 0.3.31
+    version: 0.5.0
     condition: enabled


### PR DESCRIPTION
# Why we create this PR?
 
Update digital twin registry version
Helm Chart version `v0.5.2`
AppVersion: `0.5.0`


# What is new?
 
## Updated
- Updated digital twin registry version


