### PR TITLE
Create trufflehog.yml

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -1,0 +1,41 @@
+name: "TruffleHog"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *" # Once a day
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+  id-token: write
+  issues: write
+
+jobs:
+  ScanSecrets:
+    name: Scan secrets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Ensure full clone for pull request workflows
+          ref: ${{ github.head_ref }}  # Fetch specific branch/commit for pull requests
+
+      - name: TruffleHog OSS
+        id: trufflehog
+        uses: trufflesecurity/trufflehog@main
+        continue-on-error: true
+        with:
+          path: ./  # Scan the entire repository
+          base: "${{ github.event.repository.default_branch }}"  # Set base branch for comparison (pull requests)
+          extra_args: --filter-entropy=4 --results=verified,unknown --debug
+      
+      - name: Scan Results Status
+        if: steps.trufflehog.outcome == 'failure'
+        run: exit 1  # Set workflow run to failure if TruffleHog finds secrets


### PR DESCRIPTION
# Why we create this PR?
 
This PR introduces TruffleHog as a new open source tool for secret scanning to be used alongside native Github Secret scanning. This is being enforced as a replacement to the existing GitGuardian (commercial) tool.
 
# What we want to achieve with this PR?
 
The TRG checks continues for 24.08 under GitGuardian for secret scanning.
If you have already implemented TruffleHog, it can also be considered for the TRG checks.
 
## PR Linked to:

[Update trg-8-03.md](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/pull/950)

<!--
Include here the issues if available that will be closed with this PR.
Use the notation `Closes #<issueId>`
-->
