### PR TITLE
Hotfix: Add TruffleHog workflow for Secret Scanning

### DIFF
--- a/.github/workflows/trufflehog.yaml
+++ b/.github/workflows/trufflehog.yaml
@@ -28,14 +28,14 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-name: "TruffleHog"
+name: "TruffleHog - Secret Scanning"
 
 on:
   push:
-    branches: ["main", "chore/feature/trg-8-03-trufflehog"]
+    branches: ["main"]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: ["main", "chore/feature/trg-8-03-trufflehog"]
+    branches: ["main"]
   schedule:
     - cron: "0 0 * * *" # Once a day
   workflow_dispatch:

--- a/.github/workflows/trufflehog.yaml
+++ b/.github/workflows/trufflehog.yaml
@@ -1,0 +1,77 @@
+#################################################################################
+# Tractus-X - Digital Product Pass Application
+#
+# Copyright (c) 2022, 2024 BMW AG
+# Copyright (c) 2022, 2024 Henkel AG & Co. KGaA
+# Copyright (c) 2023, 2024 CGI Deutschland B.V. & Co. KG
+# Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: "TruffleHog"
+
+on:
+  push:
+    branches: ["main", "chore/feature/trg-8-03-trufflehog"]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: ["main", "chore/feature/trg-8-03-trufflehog"]
+  schedule:
+    - cron: "0 0 * * *" # Once a day
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to use"
+        required: true
+        default: "main"
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+  id-token: write
+  issues: write
+
+jobs:
+  ScanSecrets:
+    name: Scan secrets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Ensure full clone for pull request workflows
+
+      - name: TruffleHog OSS
+        id: trufflehog
+        uses: trufflesecurity/trufflehog@main
+        continue-on-error: true
+        with:
+          path: ./  # Scan the entire repository
+          base: "${{ github.event.repository.default_branch }}"  # Set base branch for comparison (pull requests)
+          extra_args: --filter-entropy=4 --results=verified,unknown --debug
+      
+      - name: Scan Results Status
+        if: steps.trufflehog.outcome == 'failure'
+        run: exit 1  # Set workflow run to failure if TruffleHog finds secrets 


### PR DESCRIPTION
# Why we create this PR?
 
There is a requirement in [trg-8.03](https://eclipse-tractusx.github.io/docs/release/trg-8/trg-8-03) to introduce TruffleHog secret scanning tool as an altertive to Gitguardian. Since, Gitguardian is no more used, it should be offboarded and TruffleHog must be used in place.

# What we want to achieve with this PR?
 
Replace Gitguardian with TruffleHog tool https://eclipse-tractusx.github.io/docs/release/trg-8/trg-8-03/


 
# What is new?
 
## Added
- Added truffle hog workflow for secret scanning

## Issue(s) linked to:
Closes #414 
