### PR TITLE
Hotfix: deps(springboot): fixed springboot webmvc dependency

### DIFF
--- a/DEPENDENCIES_BACKEND
+++ b/DEPENDENCIES_BACKEND
@@ -126,6 +126,6 @@ maven/mavencentral/org.springframework/spring-jdbc/6.1.12, Apache-2.0, approved,
 maven/mavencentral/org.springframework/spring-tx/6.1.12, Apache-2.0, approved, #15229
 maven/mavencentral/org.springframework/spring-web/6.1.12, Apache-2.0, approved, #15188
 maven/mavencentral/org.springframework/spring-webflux/6.1.12, Apache-2.0, approved, #12593
-maven/mavencentral/org.springframework/spring-webmvc/6.1.12, Apache-2.0, approved, #15182
+maven/mavencentral/org.springframework/spring-webmvc/6.1.13, Apache-2.0, approved, #15182
 maven/mavencentral/org.webjars/swagger-ui/5.13.0, Apache-2.0, approved, #14547
 maven/mavencentral/org.yaml/snakeyaml/2.0, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #7275

--- a/dpp-backend/digitalproductpass/pom.xml
+++ b/dpp-backend/digitalproductpass/pom.xml
@@ -186,6 +186,15 @@
             <version>2.5.0</version>
         </dependency>
     </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-webmvc</artifactId>
+                <version>6.1.13</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <build>
         <resources>
             <resource>


### PR DESCRIPTION
# Why we create this PR?
 
After upgrading springboot parent version, it was assumed that the security issues in child versions will be automatically resolved, however one of the child `sprintboot-webmvc` dep still contains security issues.

# What we want to achieve with this PR?
 
Added Springboot-webmvc dep to the dependency management to specify a particular version (which is a fixed security version) in pom file.
 
# What is new?
 
## Security Fix:
- Fixed springboot-webmvc dependency

## PR Linked to:

https://github.com/eclipse-tractusx/digital-product-pass/pull/417

<!--
Include here the issues if available that will be closed with this PR.
Use the notation `Closes #<issueId>`
-->
